### PR TITLE
chore(semantic-release): Configure semantic release with versioning in pyproject.toml

### DIFF
--- a/erpnextkta/__init__.py
+++ b/erpnextkta/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.0.1"
+from importlib.metadata import version as _version, PackageNotFoundError
+
+try:
+    __version__ = _version("erpnextkta")
+except PackageNotFoundError:
+    __version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "erpnextkta"
+version = "0.0.0"
 authors = [
-    { name = "Framras AS", email = "bilgi@framras.com.tr"}
+    { name = "Framras AS", email = "bilgi@framras.com.tr" }
 ]
 description = "KTA Endustri ozellestirmeleri CERKEZKOY TURKIYE"
 requires-python = ">=3.10"
 readme = "README.md"
-dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
 ]
@@ -20,12 +20,10 @@ build-backend = "flit_core.buildapi"
 # package_name = "~=1.1.0"
 
 [tool.semantic_release]
-# Location where version will be updated (single source)
-version_variables = [
-  "erpnextkta/__init__.py:__version__ = \"{version}\""
-]
+# Single source of truth: project.version in pyproject.toml
+version_toml = ["pyproject.toml:project.version"]
 
-# Use conventional commits parser
+# Use conventional commits parser (v9+)
 commit_parser = "conventional"
 
 # Tag format (tags like v1.2.3 will be created)
@@ -38,4 +36,3 @@ type = "github"
 token = { env = "GH_TOKEN" }
 ignore_token_for_push = false
 insecure = false
-


### PR DESCRIPTION
Update the project versioning to use `importlib.metadata` for dynamic version retrieval and set the version in `pyproject.toml` as the single source of truth. This change enhances version management for the project.