### PR TITLE
chore(fix): Enable zero version support in semantic release configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ commit_parser = "conventional"
 
 # Tag format (tags like v1.2.3 will be created)
 tag_format = "v{version}"
+allow_zero_version = true
 
 [tool.semantic_release.remote]
 name = "origin"


### PR DESCRIPTION
Allow zero versioning in the semantic release setup to enhance version management flexibility.