### PR TITLE
Fix: CI app retrieval to specify branch for ERPNext

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           CI: 'Yes'
         run: |
-          bench get-app erpnext $GITHUB_WORKSPACE
+          bench get-app erpnext https://github.com/frappe/erpnext --branch version-15
           bench get-app erpnextkta $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site


### PR DESCRIPTION
Update the CI workflow to explicitly specify the branch when retrieving the ERPNext application. This change ensures that the correct version is used during the build process.