### PR TITLE
fix(calisma_karti): remove tamamlanan_miktar requirement, enforce alt…

### DIFF
--- a/erpnextkta/kta_calisma_karti/api_impl/cards.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/cards.py
@@ -29,28 +29,15 @@ def _check_card_data_complete(doc):
     """Check if a Calisma Karti has the required data filled in.
 
     Returns a list of missing-data keys (empty list = complete).
-    Logic mirrors _handle_bitis validation:
-      - miktar_zorunlu_mu=1  →  tamamlanan_miktar > 0
-      - miktar_zorunlu_mu=0  →  at least 1 alt_operasyon row
     """
     missing = []
 
-    miktar_zorunlu = frappe.db.get_value(
-        "KTA Calisma Karti Operasyonlari", doc.operasyon, "miktar_zorunlu_mu"
+    alt_op_count = frappe.db.count(
+        "Calisma Karti Alt Operasyon Kayitlari",
+        {"parent": doc.name, "parenttype": "Calisma Karti"},
     )
-    if miktar_zorunlu is None:
-        miktar_zorunlu = 1  # default true
-
-    if miktar_zorunlu:
-        if float(doc.tamamlanan_miktar or 0) <= 0:
-            missing.append("tamamlanan_miktar")
-    else:
-        alt_op_count = frappe.db.count(
-            "Calisma Karti Alt Operasyon Kayitlari",
-            {"parent": doc.name, "parenttype": "Calisma Karti"},
-        )
-        if alt_op_count == 0:
-            missing.append("alt_operasyon")
+    if alt_op_count == 0:
+        missing.append("alt_operasyon")
 
     return missing
 
@@ -466,18 +453,9 @@ def _handle_bitis(doc, now, aciklama, qty):
     # 2. Add requested amount
     doc.tamamlanan_miktar = (doc.tamamlanan_miktar or 0.0) + qty
 
-    # 3. Check amount constraint
-    total_done = float(doc.tamamlanan_miktar or 0)
-    if total_done <= 0:
-        # Check operation strictness config
-        op_doc = frappe.db.get_value("KTA Calisma Karti Operasyonlari", doc.operasyon, "miktar_zorunlu_mu")
-        miktar_zorunlu_mu = op_doc if op_doc is not None else 1
-
-        if miktar_zorunlu_mu:
-            frappe.throw("Bu operasyon için tamamlanan miktar (üretim adedi) bildirilmesi zorunludur.")
-        else:
-            if not doc.get("alt_operasyon_kayitlari"):
-                frappe.throw("Üretim adedi girilmeden işlemin bitirilebilmesi için en az bir alt operasyon kaydı bulunmalıdır.")
+    # 3. Check amount constraint (Tamamlanan miktar artık zorunlu değil, alt operasyon zorunlu)
+    if not doc.get("alt_operasyon_kayitlari"):
+        frappe.throw("İşlemin bitirilebilmesi için en az bir alt operasyon kaydı bulunmalıdır.")
 
     doc.bitis_saati = now
 

--- a/erpnextkta/kta_calisma_karti/doctype/calisma_karti/test_calisma_karti.py
+++ b/erpnextkta/kta_calisma_karti/doctype/calisma_karti/test_calisma_karti.py
@@ -332,7 +332,19 @@ class TestCalismaKartiIntegration(KTATestCase):
 			"baslangic_saati": frappe.utils.add_to_date(None, minutes=-30)
 		}).insert(ignore_permissions=True, ignore_links=True)
 		
-		# Bitiş işlemi yap (miktar zorunlu ise miktar girilmeli)
+		# Alt operasyon ekle (Bitiş için zorunlu)
+		unique_title = f"Test Alt Op {frappe.generate_hash(length=8)}"
+		master_doc = frappe.get_doc({
+			"doctype": "KTA Calisma Karti Alt Operasyonlari",
+			"title": unique_title,
+			"parent_operation": self.kta_op,
+			"sequence": 10
+		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		
+		from erpnextkta.kta_calisma_karti.api_impl.alt_operasyon import add_alt_operasyon_kaydi
+		add_alt_operasyon_kaydi(doc.name, master_doc.name)
+
+		# Bitiş işlemi yap (artık miktar sorulmuyor, ama alt operasyon şart)
 		islem_yap(doc.name, "Bitis", tamamlanan_miktar=10)
 		
 		# Docstatus kontrol et (1 = Submitted)

--- a/erpnextkta/public/view-calisma-karti/App.vue
+++ b/erpnextkta/public/view-calisma-karti/App.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { useCalismaKarti } from "./composables/useCalismaKarti";
 import { useCalismaKartiUi } from "./composables/useCalismaKartiUi";
-import { durusFields, bitirFields } from "./composables/prompts";
+import { durusFields } from "./composables/prompts";
 
 import CkTopbar from "./components/CkTopbar.vue";
 import CkChips from "./components/CkChips.vue";
@@ -183,25 +183,9 @@ function onDurus() {
 }
 
 function onBitir() {
-  const isMiktarZorunlu = doc.value?.miktar_zorunlu_mu !== 0; // default true if null/undefined
-
-  if (isMiktarZorunlu) {
-    frappe.prompt(
-      bitirFields(),
-      async (v: any) => {
-        frappe.confirm("İşlem bitirilecek. Devam etmek istediğinizden emin misiniz?", async () =>
-          callIslem("Bitis", null, null, v.tamamlanan_miktar)
-        );
-      },
-      "Bitir",
-      "Devam"
-    );
-  } else {
-    // Miktar zorunlu değilse direkt bitir
-    frappe.confirm("Herhangi bir üretim miktarı bildirmeden işlem bitirilecek. Emin misiniz?", async () =>
-      callIslem("Bitis", null, null, 0)
-    );
-  }
+  frappe.confirm("İşlem bitirilecek. Devam etmek istediğinizden emin misiniz?", async () =>
+    callIslem("Bitis", null, null, 0)
+  );
 }
 
 async function setQC(nextValue: string) {

--- a/erpnextkta/public/view-calisma-karti/composables/prompts.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/prompts.ts
@@ -91,18 +91,7 @@ export function durusFields() {
     ];
 }
 
-export function bitirFields() {
-    return [
-        {
-            fieldtype: "Float",
-            label: "Tamamlanan Miktar",
-            fieldname: "tamamlanan_miktar",
-            reqd: 0,
-            default: 0,
-            description: "Varsa bitiş aşamasında tamamlanan ek miktar.",
-        },
-    ];
-}
+
 
 export function idcOlcumFields(docname: string, defaults: any = {}) {
     return [

--- a/erpnextkta/tests/test_api.py
+++ b/erpnextkta/tests/test_api.py
@@ -74,7 +74,16 @@ class TestCalismaKartiAPI(KTATestCase):
 		res = islem_yap(docname, "DevamEt")
 		self.assertEqual(res["durum"], "calisiyor")
 		
-		# 4. Bitiş
+		# 4. Bitiş (artık alt operasyon zorunlu)
+		unique_title = f"Test Alt Op {frappe.generate_hash(length=8)}"
+		master_doc = frappe.get_doc({
+			"doctype": "KTA Calisma Karti Alt Operasyonlari",
+			"title": unique_title,
+			"parent_operation": self.kta_op,
+			"sequence": 10
+		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		add_alt_operasyon_kaydi(docname, master_doc.name)
+		
 		res = islem_yap(docname, "Bitis", tamamlanan_miktar=10)
 		self.assertEqual(res["durum"], "bitmis")
 		

--- a/erpnextkta/tests/test_api.py
+++ b/erpnextkta/tests/test_api.py
@@ -17,7 +17,8 @@ class TestCalismaKartiAPI(KTATestCase):
 			create_test_operator(emp_email, emp_email.split("@")[0].capitalize())
 
 		# Ensure a clean slate for this specific test case payload across runs
-		frappe.db.delete("Calisma Karti", {"is_karti": self.jc_name, "operator": "test@kta.com"})
+		for operator in ["test@kta.com", "workflow@kta.com", "qc@kta.com", "scrap@kta.com", "altop@kta.com"]:
+			frappe.db.delete("Calisma Karti", {"is_karti": self.jc_name, "operator": operator})
 		
 		# Ensure Work Order has source_warehouse (for scrap sync)
 		frappe.db.set_value("Work Order", self.wo_name, "source_warehouse", self.wip_warehouse)


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, çalışma kartı bitiş işlemlerinde artık kullanılmayan "Tamamlanan Miktar" değerinin istenmesi sorununu ve aktif kartlar kontrol edilirken hatalı yönlendirme yaparak "Alt operasyon kaydı bulunmamaktadır" uyarısının çıkması problemini çözmektedir. Kartın başarıyla kapatılabilmesi için miktar denetimi tamamen devre dışı bırakılmış, sadece Alt Operasyon kaydının bulunması koşulu sağlanmıştır.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [x] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Kullanıcıların çalışma kartını bitirmek istediklerinde ("Bitir" veya "Başlat" butonları aracılığıyla) sistemin arka planda artık kullanılmayan "Tamamlanan Miktar" kontrolüne takılması ve kullanıcıyı ilgisiz yere "Alt operasyon kaydı bulunmamaktadır" şeklinde uyarması problemini çözmek. Bu düzeltme ile veri doğrulaması sadeleştirilmiş, sadece güncel işleyişte gerçekten kontrol edilmesi istenen "Alt operasyon eklenmiş mi?" kuralına indirgenmiştir.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- **Frontend (App.vue):** "Bitir" butonuna basıldığında ekrana çıkan "Tamamlanan Miktar" sorusu (prompt) kullanımdan kaldırıldı. İşlem doğrudan onay diyaloğu ile bitirilebilir hale getirildi.
- **Frontend (prompts.ts):** Artık herhangi bir yerde kullanılmayan `bitirFields` fonksiyonu silindi.
- **Backend (cards.py - `_check_card_data_complete`):** Eksik veri kontrolü yapılırken `miktar_zorunlu_mu` değişkenine dayalı miktar sorgulaması çıkarıldı. Sistem sadece alt operasyon tablosunda veri olup olmadığını kontrol edecek şekilde güncellendi.
- **Backend (cards.py - `_handle_bitis`):** İşlem sonlandırma (`Bitis`) sırasındaki üretim adedi bildirme zorunluluğu hatası kaldırıldı. Operasyon miktar bağımsız olarak tamamlanabilir kılındı.
- **Testler (test_api.py):** API testlerinde `Bitis` sürecine geçmeden önce zorunlu olan örnek bir alt operasyonun oluşturulup karta eklenmesi sağlandı.
  
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [x] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi

---

## 📎 Ek Notlar

Sahada "Alt operasyonu girdiğim halde eksik alt operasyon diyor" şikayetinin ana sebebi; aslında sistemin girilen alt operasyonu görmemesi değil, kullanımdan kalkan "Tamamlanan Miktarın" eksik olmasını hatalı bir hata mesajıyla (Alt Operasyon Yok diyerek) bildirmesiydi. Bu güncelleme her iki karışıklığı da kökünden çözmüştür. `fix/remove-completed-qty-constraint` branch'inde canlı sistem testlerine hazırdır.
