### PR TITLE
feat(mrp_analysis): add custom date range filter option

### DIFF
--- a/erpnextkta/kta_mrp/report/mrp_analysis/mrp_analysis.js
+++ b/erpnextkta/kta_mrp/report/mrp_analysis/mrp_analysis.js
@@ -30,8 +30,27 @@ frappe.query_reports["MRP Analysis"] = {
 			fieldname: "periyot",
 			label: __("Periyot"),
 			fieldtype: "Select",
-			options: ["Yıllık", "3 Aylık", "6 Aylık", "Süresiz"],
+			options: ["Yıllık", "3 Aylık", "6 Aylık", "Süresiz", "Özel"],
 			default: "Yıllık",
+			on_change: function () {
+				let report = frappe.query_report;
+				let periyot = report.get_filter_value("periyot");
+				let is_custom = periyot === "Özel";
+				report.get_filter("from_date").toggle(is_custom);
+				report.get_filter("to_date").toggle(is_custom);
+			},
+		},
+		{
+			fieldname: "from_date",
+			label: __("Başlangıç Tarihi"),
+			fieldtype: "Date",
+			hidden: 1,
+		},
+		{
+			fieldname: "to_date",
+			label: __("Bitiş Tarihi"),
+			fieldtype: "Date",
+			hidden: 1,
 		},
 		{
 			fieldname: "ara_malzeme_grubu",

--- a/erpnextkta/kta_mrp/report/mrp_analysis/mrp_analysis.py
+++ b/erpnextkta/kta_mrp/report/mrp_analysis/mrp_analysis.py
@@ -9,17 +9,23 @@ def execute(filters=None):
 		filters = {}
 
 	current_date = getdate(today())
-	from_date = str(current_date)
 
-	# Periyot filtresine göre to_date belirle
+	# Periyot filtresine göre tarih aralığını belirle
 	periyot = filters.get("periyot", "Yıllık")
-	if periyot == "3 Aylık":
+	if periyot == "Özel":
+		from_date = str(getdate(filters.get("from_date")) if filters.get("from_date") else current_date)
+		to_date = str(getdate(filters.get("to_date")) if filters.get("to_date") else date(current_date.year, 12, 31))
+	elif periyot == "3 Aylık":
+		from_date = str(current_date)
 		to_date = str(add_months(current_date, 3))
 	elif periyot == "6 Aylık":
+		from_date = str(current_date)
 		to_date = str(add_months(current_date, 6))
 	elif periyot == "Süresiz":
+		from_date = str(current_date)
 		to_date = "2099-12-31"
 	else:  # Yıllık (varsayılan)
+		from_date = str(current_date)
 		to_date = str(date(current_date.year, 12, 31))
 
 	# Filtre değerlerini al


### PR DESCRIPTION
Add "Özel" (Custom) period option to MRP Analysis report allowing users to specify arbitrary from_date and to_date values instead of preset periods.

# 🔀 Pull Request Açıklaması

Bu PR ne yapıyor? Kısa ve net anlatın.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

MRP Analizi raporu mevcut durumda yalnızca sabit periyotlarla (Yıllık, 3 Aylık, 6 Aylık, Süresiz) çalışabiliyordu. Kullanıcıların ihtiyaç duyduğu özel tarih aralıklarında analiz yapabilmeleri için "Özel" seçeneği eklendi.


---

## 📌 Değişiklik Özeti

mrp_analysis.js: "Özel" periyot seçeneği eklendi, seçildiğinde from_date/to_date filtreleri görünür hale geliyor
mrp_analysis.py: "Özel" periyot için kullanıcı tanımlı tarih aralığı desteği eklendi
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi

---



## 📎 Ek Notlar

Kurduğum hesapta, resmi çalışan olarak son PR'ım. Sistemin daha da büyüyeceğine olan inancım tam. Kolaylıklar dilerim. Seviliyorsunuz. 