### PR TITLE
fix(quality): allow acceptance criteria value with numeric parameter …

### DIFF
--- a/erpnextkta/erpnextkta/custom/item_quality_inspection_parameter.json
+++ b/erpnextkta/erpnextkta/custom/item_quality_inspection_parameter.json
@@ -68,6 +68,15 @@
  "custom_perms": [],
  "doctype": "Item Quality Inspection Parameter",
  "links": [],
- "property_setters": [],
+ "property_setters": [
+  {
+   "doc_type": "Item Quality Inspection Parameter",
+   "doctype_or_field": "DocField",
+   "field_name": "value",
+   "property": "depends_on",
+   "property_type": "Small Text",
+   "value": "eval:!doc.formula_based_criteria"
+  }
+ ],
  "sync_on_migrate": 1
 }

--- a/erpnextkta/erpnextkta/custom/quality_inspection_reading.json
+++ b/erpnextkta/erpnextkta/custom/quality_inspection_reading.json
@@ -1,0 +1,17 @@
+{
+ "custom_fields": [],
+ "custom_perms": [],
+ "doctype": "Quality Inspection Reading",
+ "links": [],
+ "property_setters": [
+  {
+   "doc_type": "Quality Inspection Reading",
+   "doctype_or_field": "DocField",
+   "field_name": "value",
+   "property": "depends_on",
+   "property_type": "Small Text",
+   "value": "eval:!doc.formula_based_criteria"
+  }
+ ],
+ "sync_on_migrate": 1
+}


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, hem Kalite Kontrol Şablonu (Quality Inspection Template) hem de Kalite Kontrol Belgesi (Quality Inspection) oluşturulurken, satırın **Rakamsal (Numeric)** olarak seçilmesi durumunda **Kabul Kriteri Değeri (Acceptance Criteria Value)** alanının gizlenmesini engeller. Böylece kullanıcılar sayısal sınırların yanında metinsel kabul kriteri açıklamasını da bir arada girebilirler.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Yeni Frappe sürümlerinde hücre bazlı `Depends On` kurallarının katılaştırılması nedeniyle, kalite parametresi sayısal (`numeric=1`) seçildiğinde statik kabul kriteri metin alanı (`value`) formda tamamen kilitleniyor veya gizleniyordu. Bu PR ile bu kısıtlama esnetilerek her iki alanın birlikte doldurulabilmesi amaçlanmıştır.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- **Item Quality Inspection Parameter (Şablon Satırları):** `value` alanının `Depends On` kuralı `eval:!doc.formula_based_criteria` olarak esnetildi (Önceden `!doc.numeric` koşulu da vardı).
- **Quality Inspection Reading (Kalite Kontrol Satırları):** `value` alanının `Depends On` kuralı aynı şekilde `eval:!doc.formula_based_criteria` olarak güncellendi.
- Bu özelleştirmeler, çekirdek ERPNext dosyalarına dokunmadan, tamamen `erpnextkta` uygulaması altında **Property Setter** dosyaları (`.json`) olarak tanımlandı.

---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi (Veritabanında ilgili Property Setter kayıtlarının başarıyla oluştuğu bench komutlarıyla doğrulandı).
- [ ] Unit testler güncellendi/eklendi
- [ ] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi (Çekirdek koda dokunulmadığı için upgrade-safe'tir, bir sonraki `bench migrate` işleminde otomatik olarak uygulanacaktır).

---

## 📎 Ek Notlar

Yapılan özelleştirmeler `erpnextkta` uygulaması içinde `custom` klasörüne eklendiği için deploy sonrasındaki ilk `migrate` ile otomatik devreye girecektir.
