### PR TITLE
fix(permissions): bypass standard document permission errors for oper…

### DIFF
--- a/erpnextkta/kta_calisma_karti/api_impl/cards.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/cards.py
@@ -619,6 +619,10 @@ def islem_yap(docname, islem_tipi, durus_nedeni=None, aciklama=None, tamamlanan_
     doc.check_permission("write")
     _assert_can_write_on_doc(doc)
 
+    # İşlemler arka planda Work Order ve Job Card günceller.
+    # Operatörlerin bunlara erişimi olmadığı için izinleri global olarak atlıyoruz.
+    frappe.flags.ignore_permissions = True
+
     doc.reload()
 
     if doc.docstatus not in (0, 1):

--- a/erpnextkta/kta_calisma_karti/api_impl/hurda.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/hurda.py
@@ -408,6 +408,7 @@ def add_hurda(
     doc.check_permission("read")
 
     _assert_can_write_on_doc(doc)
+    frappe.flags.ignore_permissions = True
     _assert_cost_center_allowed(hurda_nedeni)
     _assert_hurda_item_allowed_for_operation(doc, parca_no)
 
@@ -497,6 +498,7 @@ def update_hurda(
     doc.check_permission("read")
 
     _assert_can_write_on_doc(doc)
+    frappe.flags.ignore_permissions = True
     _assert_cost_center_allowed(hurda_nedeni)
     _assert_hurda_item_allowed_for_operation(doc, parca_no)
 
@@ -552,6 +554,7 @@ def delete_hurda(name: str, rowname: str):
     doc.check_permission("read")
 
     _assert_can_write_on_doc(doc)
+    frappe.flags.ignore_permissions = True
 
     child_fieldname = get_child_table_fieldname(doc, "Calisma Karti Hurda")
     rows = doc.get(child_fieldname) or []

--- a/erpnextkta/kta_calisma_karti/api_impl/job_card_sync.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/job_card_sync.py
@@ -126,6 +126,7 @@ def sync_time_log_to_job_card(calisma_karti_doc) -> None:
     job_card.save()
 
     if job_card.docstatus == 1:
+        frappe.flags.ignore_permissions = True
         job_card.update_work_order()
 
 
@@ -169,6 +170,7 @@ def remove_time_log_from_job_card(calisma_karti_doc) -> None:
     job_card.save()
 
     if job_card.docstatus == 1:
+        frappe.flags.ignore_permissions = True
         job_card.update_work_order()
 
 

--- a/erpnextkta/kta_calisma_karti/doctype/calisma_karti/calisma_karti.py
+++ b/erpnextkta/kta_calisma_karti/doctype/calisma_karti/calisma_karti.py
@@ -431,6 +431,8 @@ def create_ariza_bildirimi(calisma_karti, makine_no, ariza_nedeni, aciklama):
     if doc.durum not in ["Çalışıyor", "Duruşta"]:
         frappe.throw(_("Sadece 'Çalışıyor' veya 'Duruşta' olan kartlar için arıza bildirimi yapabilirsiniz."))
 
+    frappe.flags.ignore_permissions = True
+
     _validate_open_ariza_kaydi(doc.name)
     
     asset_name, asset_maint = _get_asset_maintenance_for_machine(makine_no)


### PR DESCRIPTION
## 📝 Description / Açıklama
Bu PR, Operatörlerin kısıtlı rollerle Çalışma Kartı üzerinden işlem yaparken (hurda girişi, üretim bitişi, arıza bildirimi vb.) arka planda güncellenen standart ERPNext belgelerine (İş Emri, Stok Girişi vb.) erişim izinlerinin olmamasından kaynaklanan tüm "PermissionError" hatalarını global olarak çözmektedir.

**Çözülen Sorun:**
Normal şartlarda "İş Emri" veya "Stok Girişi" (Stock Entry) gibi standart ERPNext belgelerine sadece yetkili personelin (Örn. Üretim Yöneticisi, Depo Sorumlusu) erişimi bulunmaktadır. Operatörler sadece "Çalışma Kartı"na erişebildikleri için, üretim bitişinde (veya hurda girişinde) arka plan senkronizasyonu çalışırken sistem `PermissionError` (BelgeTipi erişimine sahip değil) fırlatıp operatörlerin işlemlerini engelliyordu.

---

## 🔧 Changes Made / Yapılan Değişiklikler

* **`api_impl/cards.py` (`islem_yap`)**:
  - Operatör (Başlat, Duraklat, Devam Et, Bitir) işlemlerini yaparken, arka planda İş Emri (Work Order) ve Job Card senkronize edilirken oluşacak yetki hatalarını atlamak için `frappe.flags.ignore_permissions = True` eklendi. (İzin kontrolü önceden sadece Çalışma Kartı seviyesinde bırakıldı).

* **`api_impl/hurda.py`**:
  - Operatör arayüzünden `add_hurda`, `update_hurda`, `delete_hurda` fonksiyonları çağırıldığında arka planda `Stock Entry` oluşturulurken yaşanan izin engellemeleri kaldırıldı.

* **`api_impl/job_card_sync.py` (`sync_time_log_to_job_card`)**:
  - `Job Card` kaydedilirken ilişkili `Work Order` güncellenmesi aşamasında izin hatalarına (özellikle Bitiş işlemi sırasında) takılmaması için bypass mekanizması sağlamlaştırıldı.

* **`doctype/calisma_karti/calisma_karti.py` (`create_ariza_bildirimi`)**:
  - Operatörün arıza bildirimi yapması sonucunda otomatik oluşan `Asset Maintenance Log` ve `Event` (Takvim) kayıtlarının, kısıtlı roller sebebiyle başarısız olması durumu engellendi.

---

## ✅ Testing / Test Adımları
- [x] Operatör (sadece KTA Operator rolüyle) giriş yapıp üretim "Bitir" butonuna bastığında herhangi bir İş Emri erişim hatası çıkmadığı doğrulandı.
- [x] Operatör arayüzünden Hurda Ekle/Sil/Güncelle işlemlerinin sorunsuz şekilde arka planda "Stock Entry" oluşturabildiği teyit edildi.
- [x] Makine arıza bildirimi yapıldığında başarıyla bakım kaydı oluşturulduğu test edildi.
