### PR TITLE
fix: krimp form updates, qc fixes and cascade cancel

### DIFF
--- a/erpnextkta/kta_calisma_karti/api_impl/alt_operasyon.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/alt_operasyon.py
@@ -289,42 +289,49 @@ def add_alt_operasyon_kaydi(
     )
     
     # Otomatik Krimp Formu Ekleme
-    # Zeki Logic: Gelen verilere göre T1 ve T2'yi belirle (Sabit Eşleştirme)
-    # T1 her zaman Sol Uç, T2 her zaman Sağ Uç
-    sol_kontak = (hammadde_2 or "").strip()
-    sag_kontak = (hammadde_3 or "").strip()
-    sol_siyirma = float(boyut_2_mm or 0)
-    sag_siyirma = float(boyut_3_mm or 0)
-
-    krimp_kontak_1 = sol_kontak
-    siyirma_1 = sol_siyirma
-    krimp_kontak_2 = sag_kontak
-    siyirma_2 = sag_siyirma
-    
-    # Sağ uçta (T2) terminal veya sıyırma varsa, veya operasyon tipi Çift Taraf ise T2 alanlarını aç
-    is_cift_tarafli = 1 if (sag_kontak or sag_siyirma > 0 or ao_doc.get("operasyon_tipi") == "Çift Taraf") else 0
-        
-    new_krimp = doc.append(
-        "krimp_olcumleri",
-        {
-            "kablo_no": hammadde or "",
-            "hedef_kablo_boyu": float(boyut_1_mm or 0),
-            "kontak_no": krimp_kontak_1,
-            "siyirma_boyu": siyirma_1,
-            "is_cift_tarafli": is_cift_tarafli,
-            "yon_2_kontak_no": krimp_kontak_2,
-            "yon_2_siyirma_boyu": siyirma_2,
-            "olcum_tarihi": frappe.utils.now_datetime(),
-            "operator": require_my_employee(), # Default operator
-        }
+    new_krimp = None
+    op_meta = frappe.db.get_value(
+        "KTA Calisma Karti Operasyonlari", doc.operasyon,
+        ["has_krimp", "alt_operasyon_bazli_kalite"], as_dict=True
     )
+
+    if op_meta and op_meta.get("has_krimp") and op_meta.get("alt_operasyon_bazli_kalite"):
+        # Zeki Logic: Gelen verilere göre T1 ve T2'yi belirle (Sabit Eşleştirme)
+        # T1 her zaman Sol Uç, T2 her zaman Sağ Uç
+        sol_kontak = (hammadde_2 or "").strip()
+        sag_kontak = (hammadde_3 or "").strip()
+        sol_siyirma = float(boyut_2_mm or 0)
+        sag_siyirma = float(boyut_3_mm or 0)
+
+        krimp_kontak_1 = sol_kontak
+        siyirma_1 = sol_siyirma
+        krimp_kontak_2 = sag_kontak
+        siyirma_2 = sag_siyirma
+        
+        # Sağ uçta (T2) terminal veya sıyırma varsa, veya operasyon tipi Çift Taraf ise T2 alanlarını aç
+        is_cift_tarafli = 1 if (sag_kontak or sag_siyirma > 0 or ao_doc.get("operasyon_tipi") == "Çift Taraf") else 0
+            
+        new_krimp = doc.append(
+            "krimp_olcumleri",
+            {
+                "kablo_no": hammadde or "",
+                "hedef_kablo_boyu": float(boyut_1_mm or 0),
+                "kontak_no": krimp_kontak_1,
+                "siyirma_boyu": siyirma_1,
+                "is_cift_tarafli": is_cift_tarafli,
+                "yon_2_kontak_no": krimp_kontak_2,
+                "yon_2_siyirma_boyu": siyirma_2,
+                "olcum_tarihi": frappe.utils.now_datetime(),
+                "operator": require_my_employee(), # Default operator
+            }
+        )
 
     doc.flags.ignore_validate_update_after_submit = True
     doc.flags.ignore_links = True
     doc.save(ignore_permissions=True)
     frappe.db.commit()
     
-    if new_krimp.name and new_ao_row.name:
+    if new_krimp and getattr(new_krimp, "name", None) and new_ao_row.name:
         frappe.db.set_value("Calisma Karti Krimp Olcumleri", new_krimp.name, "alt_operasyon_kaydi", new_ao_row.name)
         frappe.db.commit()
     

--- a/erpnextkta/kta_calisma_karti/api_impl/krimp.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/krimp.py
@@ -335,7 +335,7 @@ def search_krimp_items(doctype, txt, searchfield, start, page_len, filters):
     )
 
 @frappe.whitelist()
-def get_krimp_book_details(kablo_no=None, kontak_no=None, selected_kesit=None):
+def get_krimp_book_details(kablo_no=None, kontak_no=None, selected_kesit=None, kalip_no=None):
     """
     Tries to find matching values from 'KTA Krimp Book' based on Cable and Terminal.
     Uses normalization to handle variations like '20 AWG' vs 'AWG20'.
@@ -359,16 +359,23 @@ def get_krimp_book_details(kablo_no=None, kontak_no=None, selected_kesit=None):
         fields=["*"]
     )
     
-    book_entry = None
+    matches = []
     for entry in potential_entries:
         if normalize_kesit(entry.kesit) == norm_target:
-            book_entry = entry
-            break
+            matches.append(entry)
             
-    if not book_entry:
+    if not matches:
         return {}
-    
-    # book_entry already found via normalized comparison above
+        
+    book_entry = None
+    if kalip_no:
+        for m in matches:
+            if m.kalip and str(m.kalip).strip() == str(kalip_no).strip():
+                book_entry = m
+                break
+                
+    if not book_entry:
+        book_entry = matches[0]
 
     # Helper to parse string values to float
     def to_f(val):

--- a/erpnextkta/kta_calisma_karti/api_impl/qc.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/qc.py
@@ -646,6 +646,10 @@ def _update_parent_qc_status_from_alt_ops(ck, latest_qa_name=None):
     if not ck.get("alt_operasyon_kayitlari"):
         return
 
+    is_alt_op_qc = frappe.get_cached_value("KTA Calisma Karti Operasyonlari", ck.operasyon, "alt_operasyon_bazli_kalite")
+    if not is_alt_op_qc:
+        return
+
     statuses = [(r.get("quality_inspection_status") or "Onay Bekliyor").strip() for r in ck.get("alt_operasyon_kayitlari")]
     
     if "Reddedildi" in statuses:
@@ -658,7 +662,7 @@ def _update_parent_qc_status_from_alt_ops(ck, latest_qa_name=None):
     ck.db_set("kalite_kontrol", final_status, update_modified=True)
     
     # Alt operasyon bazlı yapıda, ana karta hiçbir zaman belge işlenmemeli, sadece durum güncellenmeli.
-    ck.db_set("quality_inspection", "", update_modified=True)
+    ck.db_set("quality_inspection", None, update_modified=True)
 
     if final_status == "Reddedildi":
         ck.db_set("durum", "Reddedildi", update_modified=True)

--- a/erpnextkta/kta_calisma_karti/doctype/calisma_karti/calisma_karti.js
+++ b/erpnextkta/kta_calisma_karti/doctype/calisma_karti/calisma_karti.js
@@ -1,6 +1,9 @@
 frappe.ui.form.on('Calisma Karti', {
   // --- 1) Link sorgu filtreleri ---
   setup(frm) {
+    // Parent Job Card cascade iptal dialoguna girmemesi için:
+    frm.ignore_doctypes_on_cancel_all = ['Job Card'];
+
     // Açık İş Emri filtresi (custom field)
     frm.set_query('custom_work_order', () => {
       return {

--- a/erpnextkta/public/view-calisma-karti/components/KrimpSection.vue
+++ b/erpnextkta/public/view-calisma-karti/components/KrimpSection.vue
@@ -92,6 +92,14 @@ function actions(r: any) {
     <b>{{ __('Krimp Ölçümleri') }}</b>
     <div style="display:flex; gap:6px;">
       <button
+        v-if="props.canEditData && props.doc.has_krimp && !props.doc.alt_operasyon_bazli_kalite"
+        class="ck-btn ck-btn--primary"
+        style="padding: 8px 10px; font-size: 12px;"
+        @click="props.onAdd()"
+      >
+        {{ __('Ekle') }}
+      </button>
+      <button
         v-if="(props.rows||[]).length > 0"
         class="ck-btn"
         style="padding: 8px 10px; font-size: 12px;"

--- a/erpnextkta/public/view-calisma-karti/composables/dialogs/useKrimpDialogs.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/dialogs/useKrimpDialogs.ts
@@ -9,24 +9,29 @@ export function useKrimpDialogs(props: any) {
     const kesit_fld = dialog.get_field("kablo_kesiti");
     const kablo_fld = dialog.get_field("kablo_no");
     const kontak_fld = dialog.get_field("kontak_no");
+    const kalip_fld = dialog.get_field("kalip_no");
     
     const yon_2_kontak_fld = dialog.get_field("yon_2_kontak_no");
     const yon_2_kesit_fld = dialog.get_field("yon_2_kablo_kesiti");
+    const yon_2_kalip_fld = dialog.get_field("yon_2_kalip_no");
     
     dialog.last_kesit = dialog.get_value("kablo_kesiti");
     dialog.last_kablo = dialog.get_value("kablo_no");
     dialog.last_kontak = dialog.get_value("kontak_no");
+    dialog.last_kalip = dialog.get_value("kalip_no");
     dialog.last_yon_2_kontak = dialog.get_value("yon_2_kontak_no");
     dialog.last_yon_2_kesit = dialog.get_value("yon_2_kablo_kesiti");
+    dialog.last_yon_2_kalip = dialog.get_value("yon_2_kalip_no");
 
-    const updateDetails = () => {
+    const updateDetails = (is_kalip_change = false) => {
       const kesit = dialog.get_value("kablo_kesiti");
       const kontak = dialog.get_value("kontak_no");
+      const kalip = dialog.get_value("kalip_no");
 
       if (kesit && kontak) {
         frappe.call({
           method: "erpnextkta.kta_calisma_karti.api.get_krimp_book_details",
-          args: { kablo_no: dialog.get_value("kablo_no") || "", kontak_no: kontak, selected_kesit: kesit },
+          args: { kablo_no: dialog.get_value("kablo_no") || "", kontak_no: kontak, selected_kesit: kesit, kalip_no: kalip },
           callback: (r: any) => {
             if (r.message && Object.keys(r.message).length > 0) {
               const data = r.message;
@@ -37,22 +42,26 @@ export function useKrimpDialogs(props: any) {
             }
           }
         });
-        // Load kalip options separately so user can choose when multiple exist
-        frappe.call({
-          method: "erpnextkta.kta_calisma_karti.api.get_kalip_list",
-          args: { kontak_no: kontak, selected_kesit: kesit },
-          callback: (r: any) => {
-            const list: string[] = r.message || [];
-            dialog.set_df_property("kalip_no", "options", ["", ...list]);
-            if (list.length === 1) {
-              dialog.set_value("kalip_no", list[0]);
-            } else if (list.length > 1) {
-              dialog.set_value("kalip_no", "");
-            } else {
-              dialog.set_value("kalip_no", "");
+        
+        if (!is_kalip_change) {
+          // Load kalip options separately so user can choose when multiple exist
+          frappe.call({
+            method: "erpnextkta.kta_calisma_karti.api.get_kalip_list",
+            args: { kontak_no: kontak, selected_kesit: kesit },
+            callback: (r: any) => {
+              const list: string[] = r.message || [];
+              const currentKalip = dialog.get_value("kalip_no");
+              dialog.set_df_property("kalip_no", "options", ["", ...list]);
+              if (list.length === 1) {
+                dialog.set_value("kalip_no", list[0]);
+              } else if (list.length > 1) {
+                if (!list.includes(currentKalip)) dialog.set_value("kalip_no", "");
+              } else {
+                dialog.set_value("kalip_no", "");
+              }
             }
-          }
-        });
+          });
+        }
       } else {
         dialog.set_value("kalip_no", "");
         dialog.set_df_property("kalip_no", "options", [""]);
@@ -62,14 +71,15 @@ export function useKrimpDialogs(props: any) {
       }
     };
 
-    const updateYon2Details = () => {
+    const updateYon2Details = (is_kalip_change = false) => {
       const kesit = dialog.get_value("yon_2_kablo_kesiti");
       const kontak = dialog.get_value("yon_2_kontak_no");
+      const kalip = dialog.get_value("yon_2_kalip_no");
 
       if (kesit && kontak) {
         frappe.call({
           method: "erpnextkta.kta_calisma_karti.api.get_krimp_book_details",
-          args: { kablo_no: dialog.get_value("kablo_no") || "", kontak_no: kontak, selected_kesit: kesit },
+          args: { kablo_no: dialog.get_value("kablo_no") || "", kontak_no: kontak, selected_kesit: kesit, kalip_no: kalip },
           callback: (r: any) => {
             if (r.message && Object.keys(r.message).length > 0) {
               const data = r.message;
@@ -80,20 +90,26 @@ export function useKrimpDialogs(props: any) {
             }
           }
         });
-        // Load T2 kalip options
-        frappe.call({
-          method: "erpnextkta.kta_calisma_karti.api.get_kalip_list",
-          args: { kontak_no: kontak, selected_kesit: kesit },
-          callback: (r: any) => {
-            const list: string[] = r.message || [];
-            dialog.set_df_property("yon_2_kalip_no", "options", ["", ...list]);
-            if (list.length === 1) {
-              dialog.set_value("yon_2_kalip_no", list[0]);
-            } else {
-              dialog.set_value("yon_2_kalip_no", "");
+        
+        if (!is_kalip_change) {
+          // Load T2 kalip options
+          frappe.call({
+            method: "erpnextkta.kta_calisma_karti.api.get_kalip_list",
+            args: { kontak_no: kontak, selected_kesit: kesit },
+            callback: (r: any) => {
+              const list: string[] = r.message || [];
+              const currentKalip = dialog.get_value("yon_2_kalip_no");
+              dialog.set_df_property("yon_2_kalip_no", "options", ["", ...list]);
+              if (list.length === 1) {
+                dialog.set_value("yon_2_kalip_no", list[0]);
+              } else if (list.length > 1) {
+                if (!list.includes(currentKalip)) dialog.set_value("yon_2_kalip_no", "");
+              } else {
+                dialog.set_value("yon_2_kalip_no", "");
+              }
             }
-          }
-        });
+          });
+        }
       } else {
         dialog.set_value("yon_2_kalip_no", "");
         dialog.set_df_property("yon_2_kalip_no", "options", [""]);
@@ -187,6 +203,24 @@ export function useKrimpDialogs(props: any) {
       };
     }
 
+    if (kalip_fld) {
+      kalip_fld.df.onchange = () => {
+        const current_kalip = dialog.get_value("kalip_no");
+        if (dialog.last_kalip === current_kalip) return;
+        dialog.last_kalip = current_kalip;
+        updateDetails(true);
+      };
+    }
+
+    if (yon_2_kalip_fld) {
+      yon_2_kalip_fld.df.onchange = () => {
+        const current_kalip = dialog.get_value("yon_2_kalip_no");
+        if (dialog.last_yon_2_kalip === current_kalip) return;
+        dialog.last_yon_2_kalip = current_kalip;
+        updateYon2Details(true);
+      };
+    }
+
     const altOpFld = dialog.get_field("alt_operasyon_kaydi");
     if (altOpFld) {
       altOpFld.df.onchange = () => {
@@ -254,7 +288,8 @@ export function useKrimpDialogs(props: any) {
     const defaults: any = {
       calisma_karti_name: props.doc.name,
       alt_op_options: altOpOptions,
-      alt_operasyon_kaydi: altOpKaydiName || ""
+      alt_operasyon_kaydi: altOpKaydiName || "",
+      has_alt_operasyon_bazli_kalite: !!props.doc.alt_operasyon_bazli_kalite
     };
 
     if (sides) {
@@ -349,7 +384,7 @@ export function useKrimpDialogs(props: any) {
     }
 
     const dialog = frappe.prompt(
-      krimpOlcumFields({ ...row, calisma_karti_name: props.doc.name, isKutKablo, alt_op_options: altOpOptions }),
+      krimpOlcumFields({ ...row, calisma_karti_name: props.doc.name, isKutKablo, alt_op_options: altOpOptions, has_alt_operasyon_bazli_kalite: !!props.doc.alt_operasyon_bazli_kalite }),
       async (v: any) => {
         await props.onUpdateKrimp({ rowname: row.name, payload: v });
         frappe.show_alert({ message: __("Krimp ölçümü güncellendi"), indicator: "green" });
@@ -447,6 +482,7 @@ export function useKrimpDialogs(props: any) {
       calisma_karti_name: props.doc.name,
       alt_op_options: altOpOptions,
       alt_operasyon_kaydi: row.alt_operasyon_kaydi || "",
+      has_alt_operasyon_bazli_kalite: !!props.doc.alt_operasyon_bazli_kalite,
       kablo_kesiti: row.kablo_kesiti || "",
       kablo_no: row.kablo_no || "",
       kontak_no: row.kontak_no || "",

--- a/erpnextkta/public/view-calisma-karti/composables/prompts/olcum.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/prompts/olcum.ts
@@ -33,6 +33,7 @@ export function idcOlcumFields(docname: string, defaults: any = {}) {
 }
 
 export function krimpOlcumFields(defaults: any = {}) {
+    const is_manual = !defaults.has_alt_operasyon_bazli_kalite;
     return applyDecimalInputMode([
         {
             fieldtype: "Section Break",
@@ -52,6 +53,13 @@ export function krimpOlcumFields(defaults: any = {}) {
             fieldname: "makine_pres_no",
             options: "Asset",
             default: defaults.makine_pres_no || "",
+        },
+        {
+            fieldtype: "Check",
+            label: __("Çift Taraflı İşlem"),
+            fieldname: "is_cift_tarafli",
+            default: defaults.is_cift_tarafli || 0,
+            hidden: is_manual ? 0 : 1
         },
         {
             fieldtype: "Section Break",
@@ -99,17 +107,17 @@ export function krimpOlcumFields(defaults: any = {}) {
         },
         { fieldtype: "Float", label: __("T1 Sıyırma Boyu (mm)"), fieldname: "siyirma_boyu", default: defaults.siyirma_boyu ?? 0 },
         { fieldtype: "Column Break" },
-        { fieldtype: "Float", label: __("T2 Sıyırma Boyu (mm)"), fieldname: "yon_2_siyirma_boyu", default: defaults.yon_2_siyirma_boyu ?? 0 },
+        { fieldtype: "Float", label: __("T2 Sıyırma Boyu (mm)"), fieldname: "yon_2_siyirma_boyu", default: defaults.yon_2_siyirma_boyu ?? 0, depends_on: is_manual ? "eval:doc.is_cift_tarafli == 1" : undefined },
 
         { fieldtype: "Section Break", hide_border: 1 },
         { fieldtype: "Float", label: __("T1 Çapak Boyu (mm)"), fieldname: "capak_boyu", default: defaults.capak_boyu ?? 0 },
         { fieldtype: "Column Break" },
-        { fieldtype: "Float", label: __("T2 Çapak Boyu (mm)"), fieldname: "yon_2_capak_boyu", default: defaults.yon_2_capak_boyu ?? 0 },
+        { fieldtype: "Float", label: __("T2 Çapak Boyu (mm)"), fieldname: "yon_2_capak_boyu", default: defaults.yon_2_capak_boyu ?? 0, depends_on: is_manual ? "eval:doc.is_cift_tarafli == 1" : undefined },
 
         {
             fieldtype: "Section Break",
             label: __("T1 - Terminal Bilgileri"),
-            depends_on: "eval:doc.kontak_no"
+            depends_on: is_manual ? undefined : "eval:doc.kontak_no"
         },
         {
             fieldtype: "Link",
@@ -179,15 +187,9 @@ export function krimpOlcumFields(defaults: any = {}) {
             default: defaults.tel_kesme_mevcut ?? 0,
         },
         {
-            fieldtype: "Check",
-            fieldname: "is_cift_tarafli",
-            default: defaults.is_cift_tarafli || 0,
-            hidden: 1
-        },
-        {
             fieldtype: "Section Break",
             label: __("T2 - Terminal Bilgileri"),
-            depends_on: "eval:doc.yon_2_kontak_no"
+            depends_on: is_manual ? "eval:doc.is_cift_tarafli == 1" : "eval:doc.yon_2_kontak_no"
         },
         {
             fieldtype: "Link",
@@ -196,7 +198,7 @@ export function krimpOlcumFields(defaults: any = {}) {
             options: "Item",
             default: defaults.yon_2_kontak_no || "",
             reqd: 0,
-            depends_on: "eval:doc.yon_2_kontak_no",
+            depends_on: is_manual ? "eval:doc.is_cift_tarafli == 1" : "eval:doc.yon_2_kontak_no",
             get_query: () => ({
                 query: "erpnextkta.kta_calisma_karti.api.search_krimp_items",
                 filters: { calisma_karti: defaults.calisma_karti_name, type: "kontak" }
@@ -208,7 +210,7 @@ export function krimpOlcumFields(defaults: any = {}) {
             fieldname: "yon_2_kablo_kesiti",
             options: defaults.yon_2_kablo_kesiti ? ["", defaults.yon_2_kablo_kesiti] : [""],
             default: defaults.yon_2_kablo_kesiti || "",
-            depends_on: "eval:doc.yon_2_kontak_no"
+            depends_on: is_manual ? "eval:doc.is_cift_tarafli == 1" : "eval:doc.yon_2_kontak_no"
         },
         {
             fieldtype: "Section Break",

--- a/erpnextkta/tests/test_utils.py
+++ b/erpnextkta/tests/test_utils.py
@@ -288,6 +288,7 @@ class KTATestCase(FrappeTestCase):
 
 	def setUp(self):
 		super().setUp()
+		frappe.flags.use_serial_and_batch_fields = False
 		desc = self.shortDescription()
 		if desc:
 			print(f"\n🔍 [TEST] {self._testMethodName}: {desc}")


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, Krimp formu üzerindeki tek ve çift taraflı terminal operasyon mantığındaki hataları gidermekte, kalite kontrol (QC) kayıtları sırasında yaşanan veritabanı hatalarını çözmekte ve frontend üzerindeki iptal işlemlerini (cascade cancel) daha güvenli hale getirmektedir.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Bu PR, üretim ve kalite süreçlerinde karşılaşılan aşağıdaki problemleri çözer:
1. İptal zincirlemesinde (cascade cancel) İş Kartlarının (Job Card) yanlışlıkla iptal edilmesi.
2. Kalite kontrol (Quality Inspection) süreçlerinde mükerrer kayıt oluşturulması sonucu sistemin hata vermesi.
3. Krimp formunda tek veya çift taraflı terminaller seçildiğinde arka plan ve arayüz mantığının hatalı çalışması.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- Frontend üzerinde çalışan toplu iptal (cascade cancel) diyalog penceresinde `Job Card` doküman türü göz ardı edilecek şekilde filtrelendi.
- `quality_inspection` kayıtları eklenirken ortaya çıkan **"Duplicate Entry"** hatasını engellemek için doğrulama/kayıt mantığı düzeltildi.
- Krimp form bileşenlerinde tek taraflı (single sided) ve çift taraflı (double sided) terminal operasyonları için veri akışı ve form kontrolleri doğru çalışacak şekilde güncellendi.
  
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [ ] Production deploy’a etkileri değerlendirildi

---

## 📎 Ek Notlar

- "Cascade Cancel" değişikliği sadece arayüz (frontend) seviyesindeki diyalogu etkilemektedir.