### PR TITLE
Add dynamic validation and update KTA Stock Label mapping

### DIFF
--- a/erpnextkta/kta_calisma_karti/api_impl/alt_operasyon.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/alt_operasyon.py
@@ -601,6 +601,8 @@ def get_alt_operasyon_options(parent_operation: str):
         fields.append("hammadde_sayisi")
     if frappe.get_meta("KTA Calisma Karti Alt Operasyonlari").has_field("operasyon_tipi"):
         fields.append("operasyon_tipi")
+    if frappe.get_meta("KTA Calisma Karti Alt Operasyonlari").has_field("is_tuketim_hesaplanir"):
+        fields.append("is_tuketim_hesaplanir")
 
     ops = frappe.get_all(
         "KTA Calisma Karti Alt Operasyonlari",
@@ -626,7 +628,7 @@ def get_alt_operasyon_options(parent_operation: str):
             o["hammadde_sayisi"] = str(count) if count > 0 else "1"
 
     return {
-        "options": [{"label": o.title, "value": o.name, "hammadde_sayisi": o.get("hammadde_sayisi") or "1", "operasyon_tipi": o.get("operasyon_tipi") or ""} for o in ops],
+        "options": [{"label": o.title, "value": o.name, "hammadde_sayisi": o.get("hammadde_sayisi") or "1", "operasyon_tipi": o.get("operasyon_tipi") or "", "is_tuketim_hesaplanir": o.get("is_tuketim_hesaplanir", 1)} for o in ops],
         "ekran_tipi": parent_ekran_tipi
     }
 

--- a/erpnextkta/kta_calisma_karti/doctype/kta_calisma_karti_alt_operasyonlari/kta_calisma_karti_alt_operasyonlari.json
+++ b/erpnextkta/kta_calisma_karti/doctype/kta_calisma_karti_alt_operasyonlari/kta_calisma_karti_alt_operasyonlari.json
@@ -12,6 +12,7 @@
         "sequence",
         "is_active",
         "operasyon_tipi",
+        "is_tuketim_hesaplanir",
         "allowed_material_groups"
     ],
     "fields": [
@@ -48,6 +49,13 @@
             "in_list_view": 1,
             "label": "Operasyon Tipi",
             "options": "\nBlunt\nTek Taraf\nÇift Taraf"
+        },
+        {
+            "fieldname": "is_tuketim_hesaplanir",
+            "fieldtype": "Check",
+            "in_list_view": 1,
+            "label": "Tüketim Hesaplanır",
+            "default": "1"
         },
         {
             "fieldname": "allowed_material_groups",

--- a/erpnextkta/kta_stock/doctype/kta_stock_label/kta_stock_label.json
+++ b/erpnextkta/kta_stock/doctype/kta_stock_label/kta_stock_label.json
@@ -8,6 +8,7 @@
   "print_label_to_zebra_kta",
   "section_break_nhrt",
   "supplier_delivery_note",
+  "work_order",
   "column_break_jdyk",
   "gr_posting_date",
   "do_not_split",
@@ -60,6 +61,13 @@
    "fieldtype": "Dynamic Link",
    "label": "Reference Name",
    "options": "reference_doctype",
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "work_order",
+   "fieldtype": "Link",
+   "label": "Work Order",
+   "options": "Work Order",
    "in_list_view": 1
   },
   {

--- a/erpnextkta/kta_stock/label_manager.py
+++ b/erpnextkta/kta_stock/label_manager.py
@@ -42,13 +42,19 @@ class LabelPrinter:
                 fields=[
                     "name", "item_code", "item_name", "item_group", "qty", "uom",
                     "supplier_delivery_note", "sut_barcode", "gr_posting_date", "quality_ref", "batch", "reference_name", "label_type",
-                    "source_warehouse", "target_warehouse"
+                    "source_warehouse", "target_warehouse", "work_order"
                 ]
         ):
             # Compatibility map for old ZPL templates
             data.gr_number = data.reference_name
             data.gr_source_warehouse = data.source_warehouse
             data.to_warehouse = data.target_warehouse
+            data.material_number = data.item_code
+            data.material_description = data.item_name
+            data.stock_uom = data.uom
+            data.batch_no = data.batch
+            data.sut_no = data.sut_barcode
+            data.print_date = frappe.utils.nowdate()
             data.qty = ZebraPrinterManager.format_qty(data.qty)
             formatted_data = ZebraPrinterManager.format_data(data.label_type or "Depo Giriş Etiketi", data)
             zebra_printer.send(formatted_data, label_doctype="KTA Stock Label", label_name=data.name)
@@ -86,7 +92,7 @@ class LabelPrinter:
             fieldname=[
                 "name", "item_code", "item_name", "item_group", "qty", "uom",
                 "supplier_delivery_note", "batch", "sut_barcode", "gr_posting_date", "quality_ref", "reference_name", "label_type",
-                "source_warehouse", "target_warehouse"
+                "source_warehouse", "target_warehouse", "work_order"
             ],
             as_dict=True
         )
@@ -107,6 +113,12 @@ class LabelPrinter:
         label_data.gr_number = label_data.reference_name
         label_data.gr_source_warehouse = label_data.source_warehouse
         label_data.to_warehouse = label_data.target_warehouse
+        label_data.material_number = label_data.item_code
+        label_data.material_description = label_data.item_name
+        label_data.stock_uom = label_data.uom
+        label_data.batch_no = label_data.batch
+        label_data.sut_no = label_data.sut_barcode
+        label_data.print_date = frappe.utils.nowdate()
         base_batch = label_data.batch[:7] if label_data.batch and len(label_data.batch) > 7 else label_data.batch
         for split in splits:
             label_data.qty = ZebraPrinterManager.format_qty(split.qty)
@@ -191,6 +203,7 @@ class LabelPrinter:
                 'batch': base_batch_no,
                 'qty': pack_qty,
                 'sut_barcode': sut_code,
+                'work_order': work_order_details.get("work_order"),
                 'print_count': 1,
                 'last_printed_at': frappe.utils.now(),
                 'last_printed_by': frappe.session.user or "Administrator"
@@ -507,13 +520,19 @@ def _print_pr_labels_by_names(label_names, user=None, **kwargs):
             "name", "item_code", "item_name", "item_group", "qty", "uom",
             "supplier_delivery_note", "sut_barcode", "gr_posting_date",
             "quality_ref", "do_not_split", "reference_name", "batch", "label_type",
-            "source_warehouse", "target_warehouse"
+            "source_warehouse", "target_warehouse", "work_order"
         ],
         order_by="creation asc"
     ):
         data.gr_number = data.reference_name
         data.gr_source_warehouse = data.source_warehouse
         data.to_warehouse = data.target_warehouse
+        data.material_number = data.item_code
+        data.material_description = data.item_name
+        data.stock_uom = data.uom
+        data.batch_no = data.batch
+        data.sut_no = data.sut_barcode
+        data.print_date = frappe.utils.nowdate()
         data.qty = ZebraPrinterManager.format_qty(data.qty)
         
         # Use the new label_type as template name (Depo Giriş Etiketi or İş Emri Etiketi)
@@ -671,7 +690,8 @@ def print_stock_entry_labels(stock_entry):
                         "item_name": frappe.db.get_value("Item", d.item_code, "item_name") or d.item_code,
                         "item_group": etiket_item_group,
                         "source_warehouse": s_wh,
-                        "target_warehouse": d.t_warehouse
+                        "target_warehouse": d.t_warehouse,
+                        "work_order": doc.get("work_order")
                     }).insert(ignore_permissions=True)
                 else:
                     frappe.db.set_value("KTA Stock Label", existing_label, {
@@ -679,7 +699,8 @@ def print_stock_entry_labels(stock_entry):
                         "target_warehouse": d.t_warehouse,
                         "batch": target_batch,
                         "sut_barcode": sut_code,
-                        "qty": pack_qty
+                        "qty": pack_qty,
+                        "work_order": doc.get("work_order")
                     })
 
             if musteri_paketleme_miktari and d.qty > 0:

--- a/erpnextkta/public/view-calisma-karti/composables/prompts/alt_operasyon.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/prompts/alt_operasyon.ts
@@ -240,6 +240,23 @@ export function altOperasyonFieldsSingle(parentOperationLabel: string, calismaKa
 
         {
             fieldtype: "Float",
+            label: __("Parça Boyu (mm)"),
+            description: __("Birim 'Metre' seçildiğinde tüketimi hesaplamak için doldurunuz."),
+            fieldname: "boyut_1_mm",
+            depends_on: (doc: any) => {
+                if (!doc) return false;
+                const selectedOp = altOpOptions.find((o: any) => o.value === doc.alt_operasyon || o.label === doc.alt_operasyon);
+                const isTuketim = selectedOp && selectedOp.is_tuketim_hesaplanir !== undefined ? selectedOp.is_tuketim_hesaplanir : 1;
+                if (!isTuketim) return false;
+
+                const u = (doc.uom || "").toLowerCase();
+                return u === "metre" || u === "m" || u === "meter";
+            },
+            reqd: 0,
+            default: defaults.boyut_1_mm ?? 0,
+        },
+        {
+            fieldtype: "Float",
             label: __("İşlem Adedi"),
             fieldname: "adet",
             reqd: 0,

--- a/erpnextkta/public/view-calisma-karti/views/AltOperasyonView.vue
+++ b/erpnextkta/public/view-calisma-karti/views/AltOperasyonView.vue
@@ -17,6 +17,11 @@ function isQCLocked(h: any): boolean {
   return (h.quality_inspection_status || "").trim() === "Onaylandı" && !!(h.quality_inspection || "").trim();
 }
 
+function getIsTuketimHesaplanir(h: any) {
+  const op = altOpOptions.value.find((o: any) => o.value === h.alt_operasyon || o.label === h.alt_operasyon);
+  return op && op.is_tuketim_hesaplanir !== undefined ? op.is_tuketim_hesaplanir : 1;
+}
+
 // Sort rows by sequence from master doctype (populated by backend), then by idx
 const sortedRows = computed(() => {
   const rows: any[] = props.doc?.alt_operasyon_kayitlari ?? [];
@@ -54,9 +59,24 @@ function onAltOperasyonEkle() {
   const fieldsFn = ekranTipi.value === "Çoklu Hammadde" ? altOperasyonFieldsMulti : altOperasyonFieldsSingle;
   const defaults = { alt_operasyon_bazli_kalite: props.doc.alt_operasyon_bazli_kalite };
   const fields = fieldsFn(props.doc.operasyon, props.doc.name, defaults, () => d?.get_value("alt_operasyon"), altOpOptions.value);
-  d = frappe.prompt(
-    fields,
-    async (v: any) => {
+  d = new frappe.ui.Dialog({
+    title: __("Alt İşlem Ekle"),
+    fields: fields,
+    primary_action_label: __("Kaydet"),
+    primary_action: async (v: any) => {
+      if (ekranTipi.value === "Tekli Hammadde") {
+        const uom = (v.uom || "").toLowerCase();
+        const selectedOp = altOpOptions.value.find((o: any) => o.value === v.alt_operasyon || o.label === v.alt_operasyon);
+        const isTuketim = selectedOp && selectedOp.is_tuketim_hesaplanir !== undefined ? selectedOp.is_tuketim_hesaplanir : 1;
+
+        if (isTuketim && (uom === "metre" || uom === "m" || uom === "meter")) {
+          if (!v.boyut_1_mm || v.boyut_1_mm <= 0) {
+            frappe.msgprint(__("Birim 'Metre' seçildiğinde tüketimin hesaplanabilmesi için 'Parça Boyu (mm)' alanı doldurulmalıdır."));
+            return;
+          }
+        }
+      }
+
       let islem_1 = typeof v.islem_adedi_1 !== 'undefined' ? v.islem_adedi_1 : (v.adet || 1);
       let islem_3 = v.islem_adedi_3 || 1;
 
@@ -75,11 +95,11 @@ function onAltOperasyonEkle() {
         note: v.note || null,
         uom: v.uom || null, // Capture UOM from old mode
       });
+      d.hide();
       frappe.show_alert({ message: __("Alt İşlem eklendi"), indicator: "green" });
-    },
-    __("Alt İşlem Ekle"),
-    __("Kaydet")
-  );
+    }
+  });
+  d.show();
 }
 
 function onAltOperasyonDuzenle(h: any) {
@@ -96,9 +116,24 @@ function onAltOperasyonDuzenle(h: any) {
     adet: h.adet || h.islem_adedi_1 // map islem_adedi_1 to adet for single mode edit
   };
   const fields = fieldsFn(props.doc.operasyon, props.doc.name, defaults, () => d?.get_value("alt_operasyon"), altOpOptions.value);
-  d = frappe.prompt(
-    fields,
-    async (v: any) => {
+  d = new frappe.ui.Dialog({
+    title: __("Alt İşlem Düzenle"),
+    fields: fields,
+    primary_action_label: __("Kaydet"),
+    primary_action: async (v: any) => {
+      if (ekranTipi.value === "Tekli Hammadde") {
+        const uom = (v.uom || "").toLowerCase();
+        const selectedOp = altOpOptions.value.find((o: any) => o.value === v.alt_operasyon || o.label === v.alt_operasyon);
+        const isTuketim = selectedOp && selectedOp.is_tuketim_hesaplanir !== undefined ? selectedOp.is_tuketim_hesaplanir : 1;
+
+        if (isTuketim && (uom === "metre" || uom === "m" || uom === "meter")) {
+          if (!v.boyut_1_mm || v.boyut_1_mm <= 0) {
+            frappe.msgprint(__("Birim 'Metre' seçildiğinde tüketimin hesaplanabilmesi için 'Parça Boyu (mm)' alanı doldurulmalıdır."));
+            return;
+          }
+        }
+      }
+
       let islem_1 = typeof v.islem_adedi_1 !== 'undefined' ? v.islem_adedi_1 : (v.adet || 1);
       let islem_3 = v.islem_adedi_3 || 1;
 
@@ -118,11 +153,11 @@ function onAltOperasyonDuzenle(h: any) {
         note: v.note || null,
         uom: v.uom || null,
       });
+      d.hide();
       frappe.show_alert({ message: __("Alt İşlem güncellendi"), indicator: "green" });
-    },
-    __("Alt İşlem Düzenle"),
-    __("Kaydet")
-  );
+    }
+  });
+  d.show();
 }
 
 function onAltOperasyonSil(h: any) {
@@ -199,8 +234,15 @@ function onAltOperasyonSil(h: any) {
               </div>
             </template>
             <template v-else>
-              <div class="ck-muted ck-mini-sub" v-if="h.hammadde">{{ h.hammadde }} ({{ h.adet || 0 }} {{ h.uom || '' }})</div>
-              <div class="ck-muted ck-mini-sub" v-else-if="h.adet || h.uom">{{ h.adet || 0 }} {{ h.uom || '' }}</div>
+              <div class="ck-muted ck-mini-sub" v-if="h.hammadde">
+                {{ h.hammadde }} 
+                <template v-if="h.boyut_1_mm">({{ __("Boy") }}: {{ h.boyut_1_mm }}mm) </template>
+                [{{ h.islem_adedi_1 !== undefined ? h.islem_adedi_1 : (h.adet || 0) }} {{ getIsTuketimHesaplanir(h) ? (h.uom || '') : 'Adet' }}]
+              </div>
+              <div class="ck-muted ck-mini-sub" v-else-if="h.islem_adedi_1 !== undefined || h.adet || h.uom">
+                <template v-if="h.boyut_1_mm">{{ __("Boy") }}: {{ h.boyut_1_mm }}mm </template>
+                [{{ h.islem_adedi_1 !== undefined ? h.islem_adedi_1 : (h.adet || 0) }} {{ getIsTuketimHesaplanir(h) ? (h.uom || '') : 'Adet' }}]
+              </div>
             </template>
             
             <div class="ck-muted ck-mini-sub" v-if="h.note">{{ h.note }}</div>


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, KTA Stock Label (Stok Etiketi) üzerine İş Emri bilgisinin yansımasıyla ilgili bir hatayı gidermekte ve Alt Operasyonlar için dinamik tüketim doğrulaması ile şarta bağlı "Parça Boyu" alanını arayüze eklemektedir.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Bu PR iki temel problemi çözmektedir:
1. **İş Emri (Work Order) Bilgisinin Etiketlerde Çıkmaması:** KTA Stock Label formuna `work_order` alanı eklenerek, etiket yazdırma işlemlerinde verilerin eksiksiz doldurulması sağlandı. Önceden İş Emri ve Repack tipindeki işlemler sırasında bu veriler boş çıkıyordu.
2. **Alt Operasyonlarda Doğrulama & Parça Boyu (UI):** Üretim ve operasyon ekranlarında sarfiyat (consumption) işlemlerinin daha güvenilir yapılması için arayüze dinamik doğrulama (validation) mekanizması eklendi. Ayrıca belirli koşullara bağlı olarak "Parça Boyu" alanının görünür olması sağlandı.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- `KTA Stock Label` DocType'ına (JSON) `work_order` veri alanı eklendi.
- `label_manager.py` içerisinde etiket yazdırma ve veri atama (mapping) mantığı güncellendi, İş Emri verisinin etiket şablonuna basılması sağlandı.
- Alt operasyon arayüzünde dinamik sarfiyat (consumption) kontrolleri kodlandı.
- Alt operasyon ekranına şartlı gösterilen "Parça Boyu" alanı dahil edildi.
  
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [x] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi
