### PR TITLE
fix(kta_stock): resolve Purchase Receipt batch bundle creation errors…

### DIFF
--- a/erpnextkta/overrides/KTAPurchaseReceipt.py
+++ b/erpnextkta/overrides/KTAPurchaseReceipt.py
@@ -352,6 +352,7 @@ class KTAPurchaseReceipt(PurchaseReceipt):
                             qi_items.append(d)
 
                 # Bundle'ları tek seferde hazırla (split için SLE gerekliydi)
+                self.make_bundle_using_old_serial_batch_fields()
                 self.set_serial_and_batch_bundle()
 
                 submitting_user = frappe.session.user
@@ -446,9 +447,9 @@ class KTAPurchaseReceipt(PurchaseReceipt):
             batch_doc.insert()
             needs_batch = batch_doc.name
 
-        updates = {"batch_no": needs_batch, "use_serial_batch_fields": 0}
+        updates = {"batch_no": needs_batch, "use_serial_batch_fields": 1}
         row.batch_no = needs_batch
-        row.use_serial_batch_fields = 0
+        row.use_serial_batch_fields = 1
         row.db_set(updates, commit=False)
 
     def update_stock_ledger(self, allow_negative_stock=False, via_landed_cost_voucher=False):

--- a/erpnextkta/tests/test_purchase_receipt.py
+++ b/erpnextkta/tests/test_purchase_receipt.py
@@ -228,6 +228,7 @@ class TestKTAPurchaseReceiptGKK(KTATestCase):
         # Enable batch tracking on the item for this test
         frappe.db.set_value("Item", self.item, "has_batch_no", 1)
         frappe.db.commit()
+        frappe.local.request_cache.clear()
 
         # 1. Create and submit Purchase Receipt
         pr = self.create_test_purchase_receipt()
@@ -311,6 +312,7 @@ class TestKTAPurchaseReceiptGKK(KTATestCase):
         frappe.db.set_value("Item", self.item, "inspection_required_before_purchase", 1)
         frappe.db.set_value("Item", self.item, "has_batch_no", 1)
         frappe.db.commit()
+        frappe.local.request_cache.clear()
 
         # Create Purchase Receipt with split quantity set to 2
         pr = self.create_test_purchase_receipt(qty=5)
@@ -349,6 +351,7 @@ class TestKTAPurchaseReceiptGKK(KTATestCase):
         frappe.db.set_value("Item", self.item, "inspection_required_before_purchase", 1)
         frappe.db.set_value("Item", self.item, "has_batch_no", 1)
         frappe.db.commit()
+        frappe.local.request_cache.clear()
 
         # Create Purchase Receipt with split quantity set to 2, but do_not_split = 1
         pr = self.create_test_purchase_receipt(qty=5)
@@ -379,6 +382,7 @@ class TestKTAPurchaseReceiptGKK(KTATestCase):
         frappe.db.set_value("Item", self.item, "inspection_required_before_purchase", 1)
         frappe.db.set_value("Item", self.item, "has_batch_no", 1)
         frappe.db.commit()
+        frappe.local.request_cache.clear()
 
         # Create Purchase Receipt with split quantity set to 0, and do_not_split = 1
         pr = self.create_test_purchase_receipt(qty=5)


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, ERPNext v15 güncellemesi sonrasında Mal Alım İrsaliyesi (Purchase Receipt) işlemlerinde karşılaşılan "Serial No / Batch No are mandatory" hatasını çözmektedir.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Bu PR, Frappe/ERPNext v15'in getirdiği yeni `Serial and Batch Bundle` yapısı nedeniyle, parti takipli ve Kalite Kontrol (GKK) gerektiren kalemlerin Mal Alım İrsaliyesi onaylarında stok kaydı oluşturamaması problemini gidermektedir. 

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- **V15 Batch Bundle Uyumluluğu:** `KTAPurchaseReceipt.py` dosyasında `on_submit` metodu içerisinde, parti (batch) atanan satırlar için geçici olarak `use_serial_batch_fields = 1` set edilerek `make_bundle_using_old_serial_batch_fields()` native fonksiyonu çağrıldı.
- Böylece ERPNext v15'in beklemiş olduğu `Serial and Batch Bundle` (Seri ve Parti Paketi) kayıtlarının, manuel bir müdahaleye gerek kalmadan sistem tarafından hatasız şekilde otomatik oluşturulması ve stok ledger kayıtlarının başarılı olması sağlandı.

---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [x] Unit testler güncellendi/eklendi (`test_purchase_receipt_gkk_*` senaryoları çalıştırılıp Bundle hatalarının ortadan kalktığı doğrulandı)
- [x] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi

---

## 🧩 İlgili Issue

`Closes #ISSUE_ID`

---

## 📎 Ek Notlar

- Yapılan düzeltmede ERPNext v15'in eski `batch_no` alanından yeni `serial_and_batch_bundle` yapısına geçişi için kendi sağladığı native (backward compatibility) mekanizması kullanılmıştır. Bu nedenle sistem stabilitesi korunmuştur.