### PR TITLE
feat: periodic sales order pending EUR conversion

### DIFF
--- a/erpnextkta/kta_mrp/report/periodic_sales_orders/periodic_sales_orders.js
+++ b/erpnextkta/kta_mrp/report/periodic_sales_orders/periodic_sales_orders.js
@@ -68,6 +68,12 @@ frappe.query_reports["Periodic Sales Orders"] = {
 			"label": __("Sadece Teslim Edilmemişler"),
 			"fieldtype": "Check",
 			"default": 1
+		},
+		{
+			"fieldname": "convert_pending_to_eur",
+			"label": __("Bekleyenleri EUR'ya Çevir"),
+			"fieldtype": "Check",
+			"default": 0
 		}
 	],
 

--- a/erpnextkta/kta_mrp/report/periodic_sales_orders/periodic_sales_orders.py
+++ b/erpnextkta/kta_mrp/report/periodic_sales_orders/periodic_sales_orders.py
@@ -125,6 +125,7 @@ class SatisAnalizi:
             label = self.get_period_label(end)
             self.columns.append({"label": label, "fieldname": scrub(label), "fieldtype": column_type, "width": 120})
         self.columns.append({"label": "Toplam", "fieldname": "total", "fieldtype": column_type, "width": 120})
+        self.columns.append({"label": "Toplam Fiyat", "fieldname": "total_amount", "fieldtype": "Currency", "options": "currency", "width": 120})
 
     def get_data(self):
         tree_field = {"Müşteri": "customer", "Müşteri Grubu": "customer_group", "Ürün Grubu": "item_group"}.get(self.filters.tree_type, "customer")
@@ -206,6 +207,10 @@ class SatisAnalizi:
                     row[key] = val
                     total += val
             row["total"] = total
+            if self.filters.value_quantity == "Quantity":
+                row["total_amount"] = total * (rate or 0)
+            else:
+                row["total_amount"] = total
             self.data.append(row)
 
     def append_summary_row(self):
@@ -217,6 +222,7 @@ class SatisAnalizi:
             summary_row[key] = column_total
             total += column_total
         summary_row["total"] = total
+        summary_row["total_amount"] = sum(row.get("total_amount", 0) for row in self.data if isinstance(row.get("total_amount"), (int, float)))
         if self.data: self.data.append(summary_row)
 
     def get_chart(self):
@@ -239,10 +245,13 @@ class SatisAnalizi:
         summary_row = self.data[-1]
         total_val = summary_row.get("total", 0)
         label = "Toplam Tutar" if self.filters.value_quantity != "Quantity" else "Toplam Miktar"
-        return [
+        summary = [
             {"value": total_val, "label": label, "indicator": "Green", "datatype": "Currency" if self.filters.value_quantity != "Quantity" else "Float"},
             {"value": len(self.data) - 1, "label": "Satır Sayısı", "indicator": "Blue"}
         ]
+        if self.filters.value_quantity == "Quantity":
+            summary.insert(1, {"value": summary_row.get("total_amount", 0), "label": "Toplam Tutar", "indicator": "Green", "datatype": "Currency"})
+        return summary
 
     def get_period_key(self, date_obj):
         for start, end in self.periodic_ranges:

--- a/erpnextkta/kta_mrp/report/periodic_sales_orders/periodic_sales_orders.py
+++ b/erpnextkta/kta_mrp/report/periodic_sales_orders/periodic_sales_orders.py
@@ -42,7 +42,7 @@ class SatisAnalizi:
         return self.columns, self.data, None, chart, summary
 
     def get_exchange_rates(self):
-        if not self.filters.target_currency:
+        if not self.filters.target_currency and not self.filters.convert_pending_to_eur:
             return {}
         exchange_date = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
         rates = frappe.get_all(
@@ -68,8 +68,8 @@ class SatisAnalizi:
                     except KeyError: continue
         return exchange_map
 
-    def convert(self, value, from_currency):
-        to_currency = self.filters.target_currency
+    def convert(self, value, from_currency, to_currency=None):
+        to_currency = to_currency or self.filters.target_currency
         if not to_currency or from_currency == to_currency:
             return value
         rate = self.exchange_rates.get((from_currency, to_currency))
@@ -113,8 +113,11 @@ class SatisAnalizi:
             {"label": "Ürün Adı", "fieldname": "item_name", "fieldtype": "Data", "width": 180},
             {"label": "Adres", "fieldname": "shipping_address_name", "fieldtype": "Data", "width": 180},
         ]
+        self.columns.append({"label": "Birim Fiyat", "fieldname": "rate", "fieldtype": "Currency", "options": "currency", "width": 120})
+
         if self.filters.value_quantity == "Quantity":
             self.columns.append({"label": "Birim", "fieldname": "uom", "fieldtype": "Data", "width": 100})
+            self.columns.append({"label": "Döviz Kuru", "fieldname": "currency", "fieldtype": "Data", "width": 100, "hidden": 1})
         else:
             self.columns.append({"label": "Döviz Kuru", "fieldname": "currency", "fieldtype": "Data", "width": 100})
         column_type = "Float"
@@ -126,7 +129,6 @@ class SatisAnalizi:
     def get_data(self):
         tree_field = {"Müşteri": "customer", "Müşteri Grubu": "customer_group", "Ürün Grubu": "item_group"}.get(self.filters.tree_type, "customer")
         show_pending_only = self.filters.get("show_pending_only")
-        value_expr = "GREATEST(soi.qty - soi.delivered_qty, 0)" if show_pending_only and self.filters.value_quantity == "Quantity" else "soi.amount" if not show_pending_only and self.filters.value_quantity != "Quantity" else "GREATEST(soi.qty - soi.delivered_qty, 0) * soi.rate" if self.filters.value_quantity != "Quantity" else "soi.qty"
         conditions = "so.docstatus = 1 AND so.status NOT IN ('Closed','Completed')"
         values = []
         if self.filters.from_date and self.filters.to_date:
@@ -137,21 +139,65 @@ class SatisAnalizi:
             values.append(self.filters.tree_key)
         if show_pending_only and self.filters.value_quantity == "Quantity":
             conditions += " AND soi.qty > soi.delivered_qty"
-        query = f"SELECT so.{tree_field} AS tree_key, soi.item_code, soi.item_name, so.name as sales_order, so.shipping_address_name, DATE(so.{self.date_field}) AS posting_date, {value_expr} AS value, so.currency, soi.uom FROM `tabSales Order Item` soi JOIN `tabSales Order` so ON so.name = soi.parent WHERE {conditions}"
+        query = f"SELECT so.{tree_field} AS tree_key, soi.item_code, soi.item_name, so.name as sales_order, so.shipping_address_name, DATE(so.{self.date_field}) AS posting_date, so.currency, soi.uom, soi.rate, soi.qty, soi.delivered_qty, soi.amount FROM `tabSales Order Item` soi JOIN `tabSales Order` so ON so.name = soi.parent WHERE {conditions}"
         raw_data = frappe.db.sql(query, values, as_dict=True)
+
+        item_prices_data = frappe.db.sql("""
+            SELECT `tabItem Price`.item_code, `tabItem Price`.currency, `tabItem Price`.price_list_rate
+            FROM `tabItem Price`
+            JOIN `tabPrice List` ON `tabPrice List`.name = `tabItem Price`.price_list
+            WHERE `tabPrice List`.selling = 1
+            ORDER BY IFNULL(`tabItem Price`.valid_from, '1900-01-01') DESC
+        """, as_dict=True)
+        item_prices = {}
+        for ip in item_prices_data:
+            key = (ip.item_code, ip.currency)
+            if key not in item_prices:
+                item_prices[key] = ip.price_list_rate
+
         grouped = frappe._dict()
         for row in raw_data:
             period_key = self.get_period_key(row.posting_date)
             if not period_key: continue
-            extra_key = row.currency if self.filters.value_quantity != "Quantity" else row.uom
-            group_key = (row.tree_key, row.item_code, row.item_name, row.shipping_address_name, extra_key)
-            if group_key not in grouped: grouped[group_key] = {}
-            converted_value = self.convert(row.value, row.currency) if self.filters.value_quantity != "Quantity" else row.value
-            grouped[group_key][period_key] = grouped[group_key].get(period_key, 0) + (converted_value or 0)
-        for (tree_key, item_code, item_name, shipping_address_name, extra_value), periods in grouped.items():
-            row = {"tree_key": tree_key, "item_code": item_code, "item_name": item_name, "shipping_address_name": shipping_address_name, "indent": 1}
-            if self.filters.value_quantity == "Quantity": row["uom"] = extra_value
-            else: row["currency"] = extra_value
+            
+            delivered_qty = row.delivered_qty or 0
+            qty = row.qty or 0
+            pending_qty = max(qty - delivered_qty, 0)
+            
+            parts = []
+            
+            if not show_pending_only and delivered_qty > 0:
+                parts.append({
+                    'rate': row.rate,
+                    'qty': delivered_qty,
+                    'amount': delivered_qty * row.rate,
+                    'currency': row.currency
+                })
+                
+            if pending_qty > 0:
+                current_rate = item_prices.get((row.item_code, row.currency), row.rate)
+                part_currency = row.currency
+                
+                if self.filters.convert_pending_to_eur and part_currency != "EUR":
+                    current_rate = self.convert(current_rate, part_currency, "EUR")
+                    part_currency = "EUR"
+                    
+                parts.append({
+                    'rate': current_rate,
+                    'qty': pending_qty,
+                    'amount': pending_qty * current_rate,
+                    'currency': part_currency
+                })
+                
+            for part in parts:
+                val = part['qty'] if self.filters.value_quantity == "Quantity" else part['amount']
+                group_key = (row.tree_key, row.item_code, row.item_name, row.shipping_address_name, row.uom, part['currency'], part['rate'])
+                if group_key not in grouped: grouped[group_key] = {}
+                converted_value = self.convert(val, part['currency']) if self.filters.value_quantity != "Quantity" else val
+                grouped[group_key][period_key] = grouped[group_key].get(period_key, 0) + (converted_value or 0)
+            
+        for (tree_key, item_code, item_name, shipping_address_name, uom, currency, rate), periods in grouped.items():
+            row = {"tree_key": tree_key, "item_code": item_code, "item_name": item_name, "shipping_address_name": shipping_address_name, "uom": uom, "currency": currency, "rate": rate, "indent": 1}
             total = 0
             for _, end in self.periodic_ranges:
                 key = scrub(self.get_period_label(end))


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Periyodik Satış Siparişleri (Periodic Sales Orders) raporunda, teslim edilmiş ve teslim edilmemiş (bekleyen) ürün miktarlarının finansal değerlemesinin ayrıştırılması ve bekleyen tutarların güncel kurlar üzerinden izlenebilmesi sağlandı.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Önceden rapordaki "Birim Fiyat" sütunu, siparişin tamamı için satış siparişi oluşturulduğu andaki eski fiyatı (`soi.rate`) baz alıyordu. Bu durum henüz faturalanmamış/teslim edilmemiş siparişlerin güncel değerini raporlamayı zorlaştırıyordu. 

Bu PR ile rapor mantığı revize edilerek; teslim edilen sipariş miktarları eski (orijinal sipariş) fiyattan, bekleyen miktarlar ise sistemdeki güncel aktif "Satış" (Selling) fiyat listesinden (`current_rate`) hesaplanacak şekilde ayrıştırılmıştır. Ayrıca kullanıcının bekleyen tutarları anlık olarak EUR para birimine çevirerek analiz edebilmesine olanak tanınmıştır.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- `periodic_sales_orders.py` içindeki SQL sorgusu revize edilerek `qty`, `delivered_qty`, `amount` ve `rate` verileri ayrı ayrı çekildi.
- Teslim edilen miktar (Delivered) ile Teslim Edilmemiş miktar (Pending) mantıksal olarak ayrıldı: Teslim edilenler sipariş anındaki fiyattan, bekleyenler ise güncel ürün satış fiyatı üzerinden ayrı satırlarda gruplandırıldı.
- `periodic_sales_orders.js` içerisine **"Bekleyenleri EUR'ya Çevir"** adında yeni bir Checkbox filtresi eklendi.
- Bu filtre aktif edildiğinde `tabCurrency Exchange` (Döviz Kurları) üzerinden son kurlar çekilerek sadece teslim edilmemiş kalemlerin fiyat/tutarlarının EUR'ya dönüştürülmesi sağlandı.
  
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi

---

## 📎 Ek Notlar

Raporda aynı ürüne ait bir sipariş için hem teslim edilen hem de bekleyen miktar varsa, artık iki farklı birim fiyat (eski sipariş fiyatı ve güncel fiyat) uygulanacağı için bu kalemler raporda iki ayrı satır halinde (fiyata göre gruplanarak) doğru toplamları verecek şekilde listelenecektir.