### PR TITLE
Decouple operation quantity and consumption amount in UI

### DIFF
--- a/erpnextkta/public/view-calisma-karti/composables/prompts/alt_operasyon.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/prompts/alt_operasyon.ts
@@ -258,9 +258,9 @@ export function altOperasyonFieldsSingle(parentOperationLabel: string, calismaKa
         {
             fieldtype: "Float",
             label: __("İşlem Adedi"),
-            fieldname: "adet",
+            fieldname: "islem_adedi_1",
             reqd: 0,
-            default: defaults.adet ?? 1,
+            default: defaults.islem_adedi_1 !== undefined ? defaults.islem_adedi_1 : (defaults.adet ?? 1),
         },
         {
             fieldtype: "Link",

--- a/erpnextkta/public/view-calisma-karti/views/AltOperasyonView.vue
+++ b/erpnextkta/public/view-calisma-karti/views/AltOperasyonView.vue
@@ -112,8 +112,7 @@ function onAltOperasyonDuzenle(h: any) {
   const fieldsFn = ekranTipi.value === "Çoklu Hammadde" ? altOperasyonFieldsMulti : altOperasyonFieldsSingle;
   const defaults = {
     ...h,
-    alt_operasyon_bazli_kalite: props.doc.alt_operasyon_bazli_kalite,
-    adet: h.adet || h.islem_adedi_1 // map islem_adedi_1 to adet for single mode edit
+    alt_operasyon_bazli_kalite: props.doc.alt_operasyon_bazli_kalite
   };
   const fields = fieldsFn(props.doc.operasyon, props.doc.name, defaults, () => d?.get_value("alt_operasyon"), altOpOptions.value);
   d = new frappe.ui.Dialog({
@@ -237,11 +236,11 @@ function onAltOperasyonSil(h: any) {
               <div class="ck-muted ck-mini-sub" v-if="h.hammadde">
                 {{ h.hammadde }} 
                 <template v-if="h.boyut_1_mm">({{ __("Boy") }}: {{ h.boyut_1_mm }}mm) </template>
-                [{{ h.islem_adedi_1 !== undefined ? h.islem_adedi_1 : (h.adet || 0) }} {{ getIsTuketimHesaplanir(h) ? (h.uom || '') : 'Adet' }}]
+                [{{ getIsTuketimHesaplanir(h) ? (h.adet || 0) : (h.islem_adedi_1 !== undefined ? h.islem_adedi_1 : (h.adet || 0)) }} {{ getIsTuketimHesaplanir(h) ? (h.uom || '') : 'Adet' }}]
               </div>
               <div class="ck-muted ck-mini-sub" v-else-if="h.islem_adedi_1 !== undefined || h.adet || h.uom">
                 <template v-if="h.boyut_1_mm">{{ __("Boy") }}: {{ h.boyut_1_mm }}mm </template>
-                [{{ h.islem_adedi_1 !== undefined ? h.islem_adedi_1 : (h.adet || 0) }} {{ getIsTuketimHesaplanir(h) ? (h.uom || '') : 'Adet' }}]
+                [{{ getIsTuketimHesaplanir(h) ? (h.adet || 0) : (h.islem_adedi_1 !== undefined ? h.islem_adedi_1 : (h.adet || 0)) }} {{ getIsTuketimHesaplanir(h) ? (h.uom || '') : 'Adet' }}]
               </div>
             </template>
             


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, Tekli Hammadde ekranında yaşanan "İşlem Adedi" ile arka planda hesaplanan "Tüketim Miktarı (adet)" arasındaki veri çakışmasını ve görsel karışıklığı gidermektedir. 

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Kullanıcıların "Kablo Kesme" gibi operasyonlarda girdikleri İşlem Adedi (örn: 18) değerinin, arayüzde ve düzenleme formunda arka planda hesaplanan toplam tüketim miktarı (örn: 24.3 Metre) tarafından ezilmesi (override edilmesi) problemini çözer. Amacımız, operatörün formda kendi girdiği orijinal işlem adedini görmesini sağlarken; ana liste görünümünde de hesaplanan tüketim miktarını net bir şekilde sunmaktır.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- **Veri Bağlantısı Düzeltildi:** `alt_operasyon.ts` içerisindeki Tekli Hammadde formu alanlarında, "İşlem Adedi" girdisinin veritabanı değişkeni `adet` yerine `islem_adedi_1` olarak değiştirildi. Böylece orijinal operatör girdisi ve arka plandaki tüketim hesaplaması (`adet`) birbirinden izole edildi.
- **Liste Görünümü Dinamikleştildi:** `AltOperasyonView.vue` içerisindeki liste görünümünde, operasyonun türüne göre gösterim akıllı hale getirildi:
  - Tüketim yapılan operasyonlarda doğrudan hesaplanan Tüketim Miktarı (Örn: `[24.3 Metre]`) gösteriliyor.
  - Tüketim yapılmayan (Ara İş) operasyonlarda doğrudan Operatörün Girdiği Adet (Örn: `[18 Adet]`) gösteriliyor.
- **Düzenleme Modu Temizliği:** Düzenle formuna girilirken tüketim miktarının form kutucuğuna zorla atanmasına sebep olan eski geri dönük uyumluluk kodları (`adet: h.adet || h.islem_adedi_1`) temizlendi.

---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [ ] Production deploy’a etkileri değerlendirildi

---

## 📎 Ek Notlar

Çoklu hammadde (Krimp vb.) ekranlarının mantığına hiçbir şekilde müdahale edilmemiştir.