### PR TITLE
Fix batch and label deletion issues in stock entry management

### DIFF
--- a/erpnextkta/kta_calisma_karti/dashboard_chart_source/operator_net_sure/operator_net_sure.js
+++ b/erpnextkta/kta_calisma_karti/dashboard_chart_source/operator_net_sure/operator_net_sure.js
@@ -13,11 +13,11 @@ frappe.dashboards.chart_sources["Operator Net Sure"] = {
             ],
         },
         {
-            fieldname: "is_istasyonu",
-            label: __("İş İstasyonu"),
+            fieldname: "department",
+            label: __("Departman"),
             fieldtype: "MultiSelectList",
-            get_data: function(txt) {
-                return frappe.db.get_link_options("Workstation", txt);
+            get_data: function (txt) {
+                return frappe.db.get_link_options("Department", txt, { parent_department: "Üretim" });
             },
         },
         {

--- a/erpnextkta/kta_calisma_karti/dashboard_chart_source/operator_net_sure/operator_net_sure.py
+++ b/erpnextkta/kta_calisma_karti/dashboard_chart_source/operator_net_sure/operator_net_sure.py
@@ -19,7 +19,7 @@ def get_data(**kwargs):
             filters = {}
 
     date_range   = filters.get("date_range")
-    is_istasyonu = filters.get("is_istasyonu") or None
+    department = filters.get("department") or None
     top_n        = int(filters.get("top_n", 15))
 
     if date_range and len(date_range) == 2:
@@ -40,12 +40,12 @@ def get_data(**kwargs):
     ]
     params = {"start": start_date, "end": end_date}
 
-    if is_istasyonu:
-        if isinstance(is_istasyonu, str):
-            is_istasyonu = [s.strip() for s in is_istasyonu.split(",") if s.strip()]
-        if is_istasyonu:
-            conditions.append("ck.is_istasyonu IN %(is_istasyonu)s")
-            params["is_istasyonu"] = is_istasyonu
+    if department:
+        if isinstance(department, str):
+            department = [s.strip() for s in department.split(",") if s.strip()]
+        if department:
+            conditions.append("emp.department IN %(department)s")
+            params["department"] = department
 
     where_clause = " AND ".join(conditions)
 

--- a/erpnextkta/kta_calisma_karti/dashboard_chart_source/tum_operatorler_net_sure/tum_operatorler_net_sure.js
+++ b/erpnextkta/kta_calisma_karti/dashboard_chart_source/tum_operatorler_net_sure/tum_operatorler_net_sure.js
@@ -19,11 +19,11 @@ frappe.dashboards.chart_sources["Tum Operatorler Net Sure"] = {
             ],
         },
         {
-            fieldname: "is_istasyonu",
-            label: __("İş İstasyonu"),
+            fieldname: "department",
+            label: __("Departman"),
             fieldtype: "MultiSelectList",
-            get_data: function(txt) {
-                return frappe.db.get_link_options("Workstation", txt);
+            get_data: function (txt) {
+                return frappe.db.get_link_options("Department", txt, { parent_department: "Üretim" });
             },
         }
     ],

--- a/erpnextkta/kta_calisma_karti/dashboard_chart_source/tum_operatorler_net_sure/tum_operatorler_net_sure.py
+++ b/erpnextkta/kta_calisma_karti/dashboard_chart_source/tum_operatorler_net_sure/tum_operatorler_net_sure.py
@@ -38,7 +38,7 @@ def get_data(**kwargs):
             filters = {}
 
     date_range   = filters.get("date_range")
-    is_istasyonu = filters.get("is_istasyonu") or None
+    department = filters.get("department") or None
 
 
     if date_range and len(date_range) == 2:
@@ -61,12 +61,12 @@ def get_data(**kwargs):
 
 
 
-    if is_istasyonu:
-        if isinstance(is_istasyonu, str):
-            is_istasyonu = [s.strip() for s in is_istasyonu.split(",") if s.strip()]
-        if is_istasyonu:
-            conditions.append("ck.is_istasyonu IN %(is_istasyonu)s")
-            params["is_istasyonu"] = is_istasyonu
+    if department:
+        if isinstance(department, str):
+            department = [s.strip() for s in department.split(",") if s.strip()]
+        if department:
+            conditions.append("emp.department IN %(department)s")
+            params["department"] = department
 
     where_clause = " AND ".join(conditions)
 
@@ -116,28 +116,38 @@ def get_data(**kwargs):
     net_values = [round(mins, 1) for op, mins in sorted_ops]
 
     missing_values = []
-    for op, mins in sorted_ops:
-        required_days = len(dates_map.get(op, set()))
-        net_val = totals[op]
-        missing_val = max(0.0, (required_days * target_duration) - net_val)
-        missing_values.append(round(missing_val, 1))
+    show_missing = True
+
+    if show_missing:
+        for op, mins in sorted_ops:
+            required_days = len(dates_map.get(op, set()))
+            net_val = totals[op]
+            missing_val = max(0.0, (required_days * target_duration) - net_val)
+            missing_values.append(round(missing_val, 1))
 
     avg_val = sum(net_values) / len(net_values) if net_values else 0
 
+    datasets = [
+        {
+            "name":      _("Net Çalışma (dk)"),
+            "values":    net_values,
+            "chartType": "bar",
+        }
+    ]
+    
+    colors = ["#3498db"]
+
+    if show_missing:
+        datasets.append({
+            "name":      _("Eksik Süre (dk) [(Gün x {0}) - Net]").format(int(target_duration)),
+            "values":    missing_values,
+            "chartType": "bar",
+        })
+        colors.append("#e74c3c")
+
     return {
         "labels": labels,
-        "datasets": [
-            {
-                "name":      _("Net Çalışma (dk)"),
-                "values":    net_values,
-                "chartType": "bar",
-            },
-            {
-                "name":      _("Eksik Süre (dk) [(Gün x {0}) - Net]").format(int(target_duration)),
-                "values":    missing_values,
-                "chartType": "bar",
-            }
-        ],
+        "datasets": datasets,
         "yMarkers": [
             {
                 "label": _("Ortalama ({0})").format(round(avg_val, 1)),
@@ -146,7 +156,7 @@ def get_data(**kwargs):
                 "options": { "labelPos": "left" }
             }
         ],
-        "colors": ["#3498db", "#e74c3c"]
+        "colors": colors
     }
 
 

--- a/erpnextkta/kta_stock/batch_manager.py
+++ b/erpnextkta/kta_stock/batch_manager.py
@@ -142,8 +142,6 @@ class BatchSplitManager:
             batch_doc.update({
                 "reference_doctype": "Work Order",
                 "reference_name": parent_doc.work_order,
-                "stock_entry_reference_doctype": "Stock Entry",
-                "stock_entry_reference_name": parent_doc.name,
                 "manufacturing_date": parent_doc.get("posting_date"),
             })
         else:
@@ -183,6 +181,10 @@ class BatchSplitManager:
             return []
 
         num_packs = cint(qty // split_qty)
+        
+        if num_packs > 300:
+            frappe.throw(_("Miktar ve paketleme oranına göre çok fazla ({0}) paket/batch oluşmaktadır. Lütfen transfer miktarını veya müşteri paketleme miktarını kontrol ediniz. (Maks: 300)").format(num_packs))
+
         remainder_qty = qty % split_qty
         allocations = []
 

--- a/erpnextkta/kta_stock/batch_manager.py
+++ b/erpnextkta/kta_stock/batch_manager.py
@@ -180,12 +180,13 @@ class BatchSplitManager:
         if split_qty <= 0:
             return []
 
+        remainder_qty = qty % split_qty
         num_packs = cint(qty // split_qty)
         
-        if num_packs > 300:
-            frappe.throw(_("Miktar ve paketleme oranına göre çok fazla ({0}) paket/batch oluşmaktadır. Lütfen transfer miktarını veya müşteri paketleme miktarını kontrol ediniz. (Maks: 300)").format(num_packs))
-
-        remainder_qty = qty % split_qty
+        total_packs = num_packs + (1 if remainder_qty > 0 else 0)
+        
+        if total_packs > 300:
+            frappe.throw(_("Miktar ve paketleme oranına göre çok fazla ({0}) paket/batch oluşmaktadır. Lütfen transfer miktarını veya müşteri paketleme miktarını kontrol ediniz. (Maks: 300)").format(total_packs))
         allocations = []
 
         start_pack_no = 1

--- a/erpnextkta/overrides/KTAStockEntry.py
+++ b/erpnextkta/overrides/KTAStockEntry.py
@@ -45,9 +45,8 @@ class KTAStockEntry(StockEntry):
         
         if self.purpose == "Manufacture":
             for batch_name in batches_to_disable:
-                frappe.db.set_value("Batch", batch_name, "batch_qty", 0, update_modified=False)
-                # Ensure the batch is marked as disabled to prevent future use if it's considered empty/cancelled.
-                frappe.db.set_value("Batch", batch_name, "disabled", 1, update_modified=False)
+                if frappe.db.exists("Batch", batch_name):
+                    frappe.db.set_value("Batch", batch_name, {"batch_qty": 0, "disabled": 1}, update_modified=False)
 
     def on_trash(self):
         batches_to_delete = []
@@ -59,12 +58,15 @@ class KTAStockEntry(StockEntry):
         
         if self.purpose == "Manufacture":
             for batch_name in batches_to_delete:
-                try:
-                    frappe.delete_doc("Batch", batch_name, ignore_permissions=True)
-                except Exception:
-                    # If deletion fails (e.g., due to LinkExistsError), ensure it's empty
-                    frappe.db.set_value("Batch", batch_name, "batch_qty", 0, update_modified=False)
-                    frappe.db.set_value("Batch", batch_name, "disabled", 1, update_modified=False)
+                if frappe.db.exists("Batch", batch_name):
+                    try:
+                        frappe.delete_doc("Batch", batch_name, ignore_permissions=True)
+                    except Exception:
+                        # If deletion fails (e.g., due to LinkExistsError), ensure it's empty and disabled
+                        frappe.db.set_value("Batch", batch_name, {
+                            "batch_qty": 0,
+                            "disabled": 1
+                        }, update_modified=False)
                     
     def _delete_associated_labels(self):
         labels = frappe.get_all("KTA Stock Label", filters={
@@ -80,11 +82,17 @@ class KTAStockEntry(StockEntry):
                 try:
                     frappe.delete_doc("KTA Print Log", log, ignore_permissions=True, force=True)
                 except Exception:
-                    pass
+                    frappe.log_error(
+                        f"Failed to delete KTA Print Log {log} for label {label} (Stock Entry {self.name}).\n{frappe.get_traceback()}",
+                        "KTAStockEntry cleanup"
+                    )
             try:
                 frappe.delete_doc("KTA Stock Label", label, ignore_permissions=True, force=True)
             except Exception:
-                pass
+                frappe.log_error(
+                    f"Failed to delete KTA Stock Label {label} (Stock Entry {self.name}).\n{frappe.get_traceback()}",
+                    "KTAStockEntry cleanup"
+                )
 
     def _get_generated_batches(self):
         batches = set()

--- a/erpnextkta/overrides/KTAStockEntry.py
+++ b/erpnextkta/overrides/KTAStockEntry.py
@@ -34,6 +34,79 @@ class KTAStockEntry(StockEntry):
             enqueue_after_commit=True,
         )
 
+    def on_cancel(self):
+        batches_to_disable = []
+        if self.purpose == "Manufacture":
+            batches_to_disable = self._get_generated_batches()
+            
+        super().on_cancel()
+        
+        self._delete_associated_labels()
+        
+        if self.purpose == "Manufacture":
+            for batch_name in batches_to_disable:
+                frappe.db.set_value("Batch", batch_name, "batch_qty", 0, update_modified=False)
+                # Ensure the batch is marked as disabled to prevent future use if it's considered empty/cancelled.
+                frappe.db.set_value("Batch", batch_name, "disabled", 1, update_modified=False)
+
+    def on_trash(self):
+        batches_to_delete = []
+        if self.purpose == "Manufacture":
+            batches_to_delete = self._get_generated_batches()
+            
+        self._delete_associated_labels()
+        super().on_trash()
+        
+        if self.purpose == "Manufacture":
+            for batch_name in batches_to_delete:
+                try:
+                    frappe.delete_doc("Batch", batch_name, ignore_permissions=True)
+                except Exception:
+                    # If deletion fails (e.g., due to LinkExistsError), ensure it's empty
+                    frappe.db.set_value("Batch", batch_name, "batch_qty", 0, update_modified=False)
+                    frappe.db.set_value("Batch", batch_name, "disabled", 1, update_modified=False)
+                    
+    def _delete_associated_labels(self):
+        labels = frappe.get_all("KTA Stock Label", filters={
+            "reference_doctype": "Stock Entry",
+            "reference_name": self.name
+        }, pluck="name")
+        for label in labels:
+            logs = frappe.get_all("KTA Print Log", filters={
+                "label_doctype": "KTA Stock Label",
+                "label_name": label
+            }, pluck="name")
+            for log in logs:
+                try:
+                    frappe.delete_doc("KTA Print Log", log, ignore_permissions=True, force=True)
+                except Exception:
+                    pass
+            try:
+                frappe.delete_doc("KTA Stock Label", label, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+
+    def _get_generated_batches(self):
+        batches = set()
+        
+        # 1. Try to find bundles via voucher_no in DB (works even if doc is cancelled and row links are cleared)
+        bundles = frappe.get_all("Serial and Batch Bundle", 
+                                 filters={"voucher_type": "Stock Entry", "voucher_no": self.name},
+                                 pluck="name")
+                                 
+        # 2. Fallback to row fields if not found (e.g. before save/submit)
+        if not bundles:
+            bundles = [row.get("serial_and_batch_bundle") for row in self.get("items", []) 
+                      if row.get("is_finished_item") and row.get("serial_and_batch_bundle")]
+
+        for bundle in bundles:
+            entries = frappe.get_all("Serial and Batch Entry", 
+                                    filters={"parent": bundle, "is_outward": 0},
+                                    pluck="batch_no")
+            for b in entries:
+                if b:
+                    batches.add(b)
+        return list(batches)
 
 def print_labels_on_submit(stock_entry, user=None):
     if user:


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, üretim (manufacture) stok girişlerinin iptali veya silinmesi durumlarında batch (parti) ve etiketlerin düzgün temizlenmesi sorununu çözerken, çalışma kartlarındaki operatör net süre grafiklerinde iş istasyonu yerine departman bazlı filtrelemeye geçilmesini içerir.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

- **Stok Modülü:** "Manufacture" tipi stok girişleri (Stock Entry) iptal edildiğinde veya silindiğinde (trash), yanlışlıkla sistemde kalan veya bakiyeli görünen batch'lerin temizlenmesini ve bunlara bağlı oluşturulmuş stok etiketleri (KTA Stock Label) ile yazdırma loglarının silinmesini sağlamak. Ayrıca hatalı veri girişlerinden kaynaklı sistemin kilitlenmesini önlemek için maksimum batch (paket) sınırını (300) getirmek.
- **Çalışma Kartı Raporları:** Operatör net süre grafiklerinde (`operator_net_sure` ve `tum_operatorler_net_sure`) filtreleme mantığını "İş İstasyonu" (Workstation) yerleşik yapısından çıkarıp "Departman" (Department) bazlı (özellikle "Üretim" alt departmanları) filtrelemeye geçerek raporlamayı daha uyumlu hale getirmek.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- `KTAStockEntry` hook dosyasına `on_cancel` ve `on_trash` metotları eklenerek, Manufacture kayıtları iptal/silindiğinde ilgili Batch'lerin silinmesi veya (link hatası vs. oluşursa) `batch_qty=0` yapılarak `disabled=1` ile pasife alınması sağlandı.
- Bağlantılı `KTA Stock Label` ve `KTA Print Log` kayıtlarının temizlenmesi için `_delete_associated_labels` isimli yardımcı bir fonksiyon yazıldı.
- `BatchSplitManager` içerisine, eğer paketleme sonrası hesaplanan batch sayısı 300'ü geçerse işlemi durduran bir validasyon (hata fırlatma) eklendi.
- Operatör net süre dashboard grafiklerinde (JS ve PY dosyalarında) `is_istasyonu` alanı kaldırılıp yerine `department` eklendi. Filtre için sadece "Üretim" parent departmanına bağlı olanların listelenmesi sağlandı.

---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [x] CI Tests Passed (zorunlu)
- [x] Production deploy’a etkileri değerlendirildi

---

## 📎 Ek Notlar

Maksimum 300 paket sınırlaması, kullanıcıların yanlışlıkla hatalı transfer veya paketleme miktarı girerek sisteme aşırı yük bindirecek sayıda batch kaydı oluşturmasının önüne geçmek için eklenmiştir. Grafik tarafındaki güncellemeler, operasyonel iş akışına göre raporlama kriterlerini daha doğru yansıtacaktır.