### PR TITLE
refactor(kta_calisma_karti): implement exact matching for crimp speci…

### DIFF
--- a/erpnextkta/kta_calisma_karti/api_impl/krimp.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/krimp.py
@@ -229,13 +229,29 @@ def get_kalip_list(kontak_no=None, selected_kesit=None):
         fields=["kesit", "kalip"],
     )
 
-    norm_target = normalize_kesit(selected_kesit)
     kaliplar = []
+    
+    # 1. Try exact match first
+    exact_match_found = False
     for e in entries:
-        if normalize_kesit(e.kesit) == norm_target and e.kalip:
-            val = str(e.kalip).strip()
-            if val and val not in kaliplar:
-                kaliplar.append(val)
+        if e.kesit and str(e.kesit).strip() == str(selected_kesit).strip():
+            exact_match_found = True
+            break
+            
+    if exact_match_found:
+        for e in entries:
+            if e.kesit and str(e.kesit).strip() == str(selected_kesit).strip() and e.kalip:
+                val = str(e.kalip).strip()
+                if val and val not in kaliplar:
+                    kaliplar.append(val)
+    else:
+        # 2. Fallback to normalized match
+        norm_target = normalize_kesit(selected_kesit)
+        for e in entries:
+            if normalize_kesit(e.kesit) == norm_target and e.kalip:
+                val = str(e.kalip).strip()
+                if val and val not in kaliplar:
+                    kaliplar.append(val)
 
     return sorted(kaliplar)
 
@@ -338,31 +354,38 @@ def search_krimp_items(doctype, txt, searchfield, start, page_len, filters):
 def get_krimp_book_details(kablo_no=None, kontak_no=None, selected_kesit=None, kalip_no=None):
     """
     Tries to find matching values from 'KTA Krimp Book' based on Cable and Terminal.
-    Uses normalization to handle variations like '20 AWG' vs 'AWG20'.
+    Uses exact match for selected_kesit if provided.
+    Falls back to normalization to handle variations like '20 AWG' vs 'AWG20' if relying on cable item.
     """
     if not kontak_no:
         return {}
 
-    norm_target = normalize_kesit(selected_kesit)
-    
-    if not norm_target and kablo_no:
-        # If no kesit selected, try to extract from cable
-        raw_val = extract_kesit_from_item(kablo_no)
-        norm_target = normalize_kesit(raw_val)
-
-    if not norm_target:
-        return {}
-    
-    # Fetch entries for this contact and compare normalized kesit
+    # Fetch entries for this contact
     potential_entries = frappe.get_all("KTA Krimp Book", 
         filters={"kontak_no": kontak_no}, 
         fields=["*"]
     )
     
     matches = []
-    for entry in potential_entries:
-        if normalize_kesit(entry.kesit) == norm_target:
-            matches.append(entry)
+    
+    # 1. Try exact match if selected_kesit is provided
+    if selected_kesit:
+        for entry in potential_entries:
+            if entry.kesit and str(entry.kesit).strip() == str(selected_kesit).strip():
+                matches.append(entry)
+
+    # 2. If no exact match and kablo_no is provided, fallback to extracted kesit
+    if not matches:
+        norm_target = normalize_kesit(selected_kesit)
+        if not norm_target and kablo_no:
+            # If no kesit selected, try to extract from cable
+            raw_val = extract_kesit_from_item(kablo_no)
+            norm_target = normalize_kesit(raw_val)
+
+        if norm_target:
+            for entry in potential_entries:
+                if normalize_kesit(entry.kesit) == norm_target:
+                    matches.append(entry)
             
     if not matches:
         return {}

--- a/erpnextkta/public/view-calisma-karti/composables/dialogs/useKrimpDialogs.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/dialogs/useKrimpDialogs.ts
@@ -223,7 +223,7 @@ export function useKrimpDialogs(props: any) {
 
     const altOpFld = dialog.get_field("alt_operasyon_kaydi");
     if (altOpFld) {
-      altOpFld.df.onchange = () => {
+      altOpFld.df.onchange = async () => {
         const rowId = dialog.get_value("alt_operasyon_kaydi");
         const altOpRow = getAltOpRow(rowId);
         if (altOpRow) {
@@ -240,7 +240,21 @@ export function useKrimpDialogs(props: any) {
               dialog.set_value("yon_2_siyirma_boyu", 0);
             }
           }
-          if (altOpRow.hammadde) dialog.set_value("kablo_no", altOpRow.hammadde);
+          
+          let isKutKablo = false;
+          if (altOpRow.alt_operasyon) {
+            isKutKablo = await frappe.call({
+              method: "erpnextkta.kta_calisma_karti.api.is_kut_kablo_operation",
+              args: { operasyon_name: altOpRow.alt_operasyon }
+            }).then((r: any) => r.message || false);
+          }
+          
+          if (isKutKablo && altOpRow.hammadde) {
+            dialog.set_value("kablo_no", altOpRow.hammadde);
+          } else {
+            dialog.set_value("kablo_no", "");
+          }
+
           if (altOpRow.satir_no) dialog.set_value("satir_no", altOpRow.satir_no);
           if (altOpRow.boyut_1_mm) dialog.set_value("hedef_kablo_boyu", parseFloat(altOpRow.boyut_1_mm));
         }
@@ -272,7 +286,7 @@ export function useKrimpDialogs(props: any) {
     };
   }
 
-  function addKrimp(altOpKaydiName?: string) {
+  async function addKrimp(altOpKaydiName?: string) {
     const altOpOptions = [
       "",
       ...(props.doc.alt_operasyon_kayitlari || [])
@@ -284,6 +298,14 @@ export function useKrimpDialogs(props: any) {
 
     const altOpRow = getAltOpRow(altOpKaydiName);
     const sides = resolveAltOpSides(altOpRow);
+    
+    let isKutKablo = false;
+    if (altOpRow && altOpRow.alt_operasyon) {
+      isKutKablo = await frappe.call({
+        method: "erpnextkta.kta_calisma_karti.api.is_kut_kablo_operation",
+        args: { operasyon_name: altOpRow.alt_operasyon }
+      }).then((r: any) => r.message || false);
+    }
 
     const defaults: any = {
       calisma_karti_name: props.doc.name,
@@ -303,7 +325,11 @@ export function useKrimpDialogs(props: any) {
     }
     
     if (altOpRow) {
-      defaults.kablo_no = altOpRow.hammadde || "";
+      if (isKutKablo) {
+        defaults.kablo_no = altOpRow.hammadde || "";
+      } else {
+        defaults.kablo_no = "";
+      }
       defaults.satir_no = altOpRow.satir_no || "";
       defaults.hedef_kablo_boyu = parseFloat(altOpRow.boyut_1_mm || 0);
     }


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, Krimp ekleme diyaloğunda yaşanan "terminal/kontak işlemlerinde kablo alanının otomatik dolması" problemini çözmektedir. İşlem türüne göre dinamik kontrol eklenerek, küt kablo harici operasyonlarda kablo alanına yapılan hatalı otomatik doldurmalar engellenmiştir.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Bu PR hangi problemi çözüyor veya hangi davranışı ekliyor?

Kullanıcılar "Kontak Basma" gibi alt operasyonları seçtiğinde sistem, ana hammadde alanındaki değeri (terminal kodu vb.) doğrudan kabloymuş gibi varsayıp Krimp diyalog penceresindeki "Kablo No" alanına dolduruyordu. Bu PR sayesinde, arka uca (`is_kut_kablo_operation`) operasyonun küt kablo işlemi olup olmadığı sorulmakta ve sadece işlem bir kablo işlemiyse otomatik doldurma yapılmaktadır.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- `useKrimpDialogs.ts` dosyasındaki `addKrimp` ve `setupKrimpBookLogic` form metotlarına asenkron `is_kut_kablo_operation` kontrolü eklendi.
- "Kablo No" alanının, yalnızca `isKutKablo` doğrulandığında `hammadde` değeri ile otomatik dolması sağlandı.
- Operasyon küt kablo işlemi değilse (örn. Kontak Basma), "Kablo No" alanının her durumda boş (temizlenmiş) gelmesi garanti altına alındı.
  
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [ ] CI Tests Passed (zorunlu)
- [ ] Production deploy’a etkileri değerlendirildi

---

## 🧩 İlgili Issue

Kapatılacak veya ilişkilendirilecek issue’yu ekleyin:

`Closes #ISSUE_ID` *(Uygun issue numarasını buraya yazabilirsiniz)*

---

## 📎 Ek Notlar

"Kontak Basma" işlemi için terminal alanına ana hammaddeden otomatik atama yapma fikri değerlendirilmiş olup, `alt_operasyon_bazli_kalite` mantığı gereği terminal (T1/T2) bilgilerinin `hammadde_2` vb. üzerinden yönetilmesi uygun bulunduğu için, terminal (kontak) alanlarına sistemsel ek bir atama müdahalesi yapılmamış; eski orjinal halinde bırakılmıştır.
