### PR TITLE
fix(kta_calisma_karti): handle multi-material & auto-fill terminal for non-cable ops

### DIFF
--- a/erpnextkta/kta_calisma_karti/api_impl/alt_operasyon.py
+++ b/erpnextkta/kta_calisma_karti/api_impl/alt_operasyon.py
@@ -303,7 +303,13 @@ def add_alt_operasyon_kaydi(
         sol_siyirma = float(boyut_2_mm or 0)
         sag_siyirma = float(boyut_3_mm or 0)
 
+        is_kut_kablo = is_kut_kablo_operation(alt_operasyon)
+        is_coklu = _is_coklu_hammadde(calisma_karti)
+
         krimp_kontak_1 = sol_kontak
+        if not is_coklu and not is_kut_kablo and hammadde and not krimp_kontak_1:
+            krimp_kontak_1 = hammadde
+            
         siyirma_1 = sol_siyirma
         krimp_kontak_2 = sag_kontak
         siyirma_2 = sag_siyirma
@@ -314,7 +320,7 @@ def add_alt_operasyon_kaydi(
         new_krimp = doc.append(
             "krimp_olcumleri",
             {
-                "kablo_no": hammadde or "",
+                "kablo_no": hammadde if (is_coklu or is_kut_kablo) else "",
                 "hedef_kablo_boyu": float(boyut_1_mm or 0),
                 "kontak_no": krimp_kontak_1,
                 "siyirma_boyu": siyirma_1,
@@ -522,7 +528,11 @@ def update_alt_operasyon_kaydi(
     krimp_row_id = next((r.name for r in doc.get("krimp_olcumleri") if r.alt_operasyon_kaydi == row_id), None)
     if krimp_row_id:
         krimp_row = doc.get("krimp_olcumleri", {"name": krimp_row_id})[0]
-        krimp_row.kablo_no = hammadde or ""
+        
+        is_kut_kablo = is_kut_kablo_operation(alt_operasyon)
+        is_coklu = _is_coklu_hammadde(calisma_karti)
+        
+        krimp_row.kablo_no = hammadde if (is_coklu or is_kut_kablo) else ""
         krimp_row.hedef_kablo_boyu = float(boyut_1_mm or 0)
         
         # Zeki Logic: Gelen verilere göre T1 ve T2'yi belirle (Sabit Eşleştirme)
@@ -533,6 +543,9 @@ def update_alt_operasyon_kaydi(
         sag_siyirma = float(boyut_3_mm or 0)
 
         krimp_kontak_1 = sol_kontak
+        if not is_coklu and not is_kut_kablo and hammadde and not krimp_kontak_1:
+            krimp_kontak_1 = hammadde
+            
         siyirma_1 = sol_siyirma
         krimp_kontak_2 = sag_kontak
         siyirma_2 = sag_siyirma

--- a/erpnextkta/public/view-calisma-karti/composables/dialogs/useKrimpDialogs.ts
+++ b/erpnextkta/public/view-calisma-karti/composables/dialogs/useKrimpDialogs.ts
@@ -249,10 +249,20 @@ export function useKrimpDialogs(props: any) {
             }).then((r: any) => r.message || false);
           }
           
-          if (isKutKablo && altOpRow.hammadde) {
+          let isCokluHammadde = false;
+          if (props.doc && props.doc.operasyon) {
+            isCokluHammadde = await frappe.db.get_value("KTA Calisma Karti Operasyonlari", props.doc.operasyon, "ekran_tipi")
+              .then((r: any) => r.message && r.message.ekran_tipi === "Çoklu Hammadde");
+          }
+          
+          if ((isKutKablo || isCokluHammadde) && altOpRow.hammadde) {
             dialog.set_value("kablo_no", altOpRow.hammadde);
           } else {
             dialog.set_value("kablo_no", "");
+          }
+          
+          if (!isCokluHammadde && !isKutKablo && altOpRow.hammadde) {
+            dialog.set_value("kontak_no", altOpRow.hammadde);
           }
 
           if (altOpRow.satir_no) dialog.set_value("satir_no", altOpRow.satir_no);
@@ -307,6 +317,12 @@ export function useKrimpDialogs(props: any) {
       }).then((r: any) => r.message || false);
     }
 
+    let isCokluHammadde = false;
+    if (props.doc && props.doc.operasyon) {
+      isCokluHammadde = await frappe.db.get_value("KTA Calisma Karti Operasyonlari", props.doc.operasyon, "ekran_tipi")
+        .then((r: any) => r.message && r.message.ekran_tipi === "Çoklu Hammadde");
+    }
+
     const defaults: any = {
       calisma_karti_name: props.doc.name,
       alt_op_options: altOpOptions,
@@ -325,10 +341,14 @@ export function useKrimpDialogs(props: any) {
     }
     
     if (altOpRow) {
-      if (isKutKablo) {
+      if (isKutKablo || isCokluHammadde) {
         defaults.kablo_no = altOpRow.hammadde || "";
       } else {
         defaults.kablo_no = "";
+      }
+      
+      if (!isCokluHammadde && !isKutKablo && altOpRow.hammadde) {
+        defaults.kontak_no = altOpRow.hammadde;
       }
       defaults.satir_no = altOpRow.satir_no || "";
       defaults.hedef_kablo_boyu = parseFloat(altOpRow.boyut_1_mm || 0);


### PR DESCRIPTION
# 🔀 Pull Request Açıklaması

Bu PR, Krimp diyaloğu ve arka plan krimp atama sistemindeki "Kablo No" ve "Terminal" alanlarının hatalı dolma problemlerini çözmektedir. Hem "Tekli Hammadde" hem de "Çoklu Hammadde" ekranlarında girilen değerlerin operasyon türüne göre (Küt Kablo veya Kontak Basma) doğru yerlere atanmasını sağlar.

---

## ✔️ Tür (PR Type)

Lütfen uygun olanı seçin:

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔧 Refactor / Code Cleanup
- [ ] 📚 Documentation
- [ ] 🚀 CI/CD / Deployment
- [ ] ⛓ Infrastructure / Config

---

## 🎯 Amaç

Bu PR hangi problemi çözüyor veya hangi davranışı ekliyor?

1. **Çoklu Hammadde Problemi:** Daha önceki kısıtlamadan dolayı Çoklu Hammadde ekranlarında, işlem Kontak Basma olsa bile "Kablo No" alanı boş geliyordu (halbuki bu ekranda birinci kutu her zaman kablodur). Bu durum düzeltildi.
2. **Tekli Hammadde Problemi:** Tekli hammadde ekranlarında (örn. OP11 - Doppel), seçilen küt kablo değilse girilen değer kablo alanına değil, otomatik olarak "Terminal (T1)" alanına yönlendirildi. Böylece veri tutarlılığı sağlandı.

---

## 📌 Değişiklik Özeti

Başlıca yapılan değişiklikler:

- `useKrimpDialogs.ts` dosyasında `ekran_tipi` asenkron olarak sorgulanıp `isCokluHammadde` tespiti yapıldı.
- `useKrimpDialogs.ts`'de "Çoklu Hammadde" ise veya işlem küt kablo ise `hammadde`nin "Kablo No" alanına yazılması kuralı eklendi. Aksi takdirde (Tekli hammadde ve kontak işlemi ise) değerin T1 (kontak_no) alanına yazılması sağlandı.
- Aynı mantık, otomatik krimp formlarının atıldığı `alt_operasyon.py` (backend) içerisindeki `add_alt_operasyon_kaydi` ve `update_alt_operasyon_kaydi` metotlarına da eklenerek backend ve frontend tamamen senkronize edildi.
  
---

## 🧪 Test Durumu

Nasıl test edildi?

- [x] Lokal test edildi
- [ ] Unit testler güncellendi/eklendi
- [ ] CI Tests Passed (zorunlu)
- [ ] Production deploy’a etkileri değerlendirildi

---

## 📎 Ek Notlar

Test Senaryoları:
- Tekli ekranda "Kablo Kesme" seçilirse -> Değer Kablo No'ya dolar.
- Tekli ekranda "Doppel / Kontak Basma" seçilirse -> Değer Terminal T1'e dolar (Kablo boş kalır).
- Çoklu ekranda "Kontak Basma" seçilirse -> Ana hammadde Kablo No'ya, T1 değeri Terminal T1'e dolar.
